### PR TITLE
Moving IR to MIR

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,188 +1,188 @@
-use crate::ir::{builtin_type, BuiltinFn, Command, Context, DefId, Definition, Function, Struct};
+// use crate::ir::{builtin_type, BuiltinFn, Command, Context, DefId, Definition, Function, Struct};
 
-pub struct RustFile {
-    output_src: String,
-    expression_stack: Vec<String>,
-}
+// pub struct RustFile {
+//     output_src: String,
+//     expression_stack: Vec<String>,
+// }
 
-impl RustFile {
-    pub fn output_raw(&mut self, output: &str) {
-        self.output_src += output;
-    }
+// impl RustFile {
+//     pub fn output_raw(&mut self, output: &str) {
+//         self.output_src += output;
+//     }
 
-    pub fn delay_expr(&mut self, expr: String) {
-        self.expression_stack.push(expr);
-    }
+//     pub fn delay_expr(&mut self, expr: String) {
+//         self.expression_stack.push(expr);
+//     }
 
-    pub fn new() -> RustFile {
-        RustFile {
-            output_src: String::new(),
-            expression_stack: vec![],
-        }
-    }
+//     pub fn new() -> RustFile {
+//         RustFile {
+//             output_src: String::new(),
+//             expression_stack: vec![],
+//         }
+//     }
 
-    pub fn render(self) -> String {
-        self.output_src
-    }
-}
+//     pub fn render(self) -> String {
+//         self.output_src
+//     }
+// }
 
-fn codegen_type(c: &Context, ty: DefId) -> String {
-    match ty {
-        builtin_type::I32 => "i32".into(),
-        builtin_type::VOID => "()".into(),
-        builtin_type::STRING => "String".into(),
-        _ => {
-            let definition = &c.definitions[ty];
-            match definition {
-                Definition::Borrow(builtin_type::STRING) => "&str".into(),
-                Definition::Borrow(x) => format!("&{}", codegen_type(c, *x)),
-                _ => unimplemented!("Cannot codegen type"),
-            }
-        }
-    }
-}
+// fn codegen_type(c: &Context, ty: DefId) -> String {
+//     match ty {
+//         builtin_type::I32 => "i32".into(),
+//         builtin_type::VOID => "()".into(),
+//         builtin_type::STRING => "String".into(),
+//         _ => {
+//             let definition = &c.definitions[ty];
+//             match definition {
+//                 Definition::Borrow(builtin_type::STRING) => "&str".into(),
+//                 Definition::Borrow(x) => format!("&{}", codegen_type(c, *x)),
+//                 _ => unimplemented!("Cannot codegen type"),
+//             }
+//         }
+//     }
+// }
 
-pub fn codegen_fn(rust: &mut RustFile, c: &Context, f: &Function) {
-    rust.output_raw(&("fn ".to_string() + &f.name + "("));
-    let mut after_first = false;
-    for param in &f.params {
-        if after_first {
-            rust.output_raw(", ");
-        } else {
-            after_first = true;
-        }
-        rust.output_raw(&param.name);
-        rust.output_raw(": ");
-        rust.output_raw(&codegen_type(c, param.ty));
-    }
-    rust.output_raw(") -> ");
-    rust.output_raw(&codegen_type(c, f.ret_ty));
+// pub fn codegen_fn(rust: &mut RustFile, c: &Context, f: &Function) {
+//     rust.output_raw(&("fn ".to_string() + &f.name + "("));
+//     let mut after_first = false;
+//     for param in &f.params {
+//         if after_first {
+//             rust.output_raw(", ");
+//         } else {
+//             after_first = true;
+//         }
+//         rust.output_raw(&param.name);
+//         rust.output_raw(": ");
+//         rust.output_raw(&codegen_type(c, param.ty));
+//     }
+//     rust.output_raw(") -> ");
+//     rust.output_raw(&codegen_type(c, f.ret_ty));
 
-    rust.output_raw(" {\n");
+//     rust.output_raw(" {\n");
 
-    for param in &f.params {
-        rust.output_raw(&format!("let v{} = {};\n", param.var_id, param.name));
-    }
+//     for param in &f.params {
+//         rust.output_raw(&format!("let v{} = {};\n", param.var_id, param.name));
+//     }
 
-    for command in &f.body {
-        match command {
-            Command::VarUse(id) => rust.delay_expr(format!("v{}", id)),
-            Command::VarDeclWithInit(id) => {
-                let init_expr = rust.expression_stack.pop().unwrap();
-                rust.output_raw(&format!("let v{} = {};\n", id, init_expr));
-            }
-            Command::ConstInt(i) => rust.delay_expr(format!("{}", i)),
-            Command::ConstString(s) => rust.delay_expr(format!("\"{}\"", s)),
-            Command::Add => {
-                let rhs_expr = rust.expression_stack.pop().unwrap();
-                let lhs_expr = rust.expression_stack.pop().unwrap();
-                rust.delay_expr(format!("({})+({})", lhs_expr, rhs_expr));
-            }
-            Command::Sub => {
-                let rhs_expr = rust.expression_stack.pop().unwrap();
-                let lhs_expr = rust.expression_stack.pop().unwrap();
-                rust.delay_expr(format!("({})-({})", lhs_expr, rhs_expr));
-            }
-            Command::Dot(rhs_field) => {
-                let lhs_expr = rust.expression_stack.pop().unwrap();
-                rust.delay_expr(format!("({}).{}", lhs_expr, rhs_field));
-            }
-            Command::Call(def_id) => {
-                if let Definition::Fn(target) = &c.definitions[*def_id] {
-                    let mut args_expr = String::new();
-                    let mut after_first = false;
-                    for _ in 0..target.params.len() {
-                        if after_first {
-                            args_expr = ", ".to_string() + &args_expr;
-                        } else {
-                            after_first = true;
-                        }
+//     for command in &f.body {
+//         match command {
+//             Command::VarUse(id) => rust.delay_expr(format!("v{}", id)),
+//             Command::VarDeclWithInit(id) => {
+//                 let init_expr = rust.expression_stack.pop().unwrap();
+//                 rust.output_raw(&format!("let v{} = {};\n", id, init_expr));
+//             }
+//             Command::ConstInt(i) => rust.delay_expr(format!("{}", i)),
+//             Command::ConstString(s) => rust.delay_expr(format!("\"{}\"", s)),
+//             Command::Add => {
+//                 let rhs_expr = rust.expression_stack.pop().unwrap();
+//                 let lhs_expr = rust.expression_stack.pop().unwrap();
+//                 rust.delay_expr(format!("({})+({})", lhs_expr, rhs_expr));
+//             }
+//             Command::Sub => {
+//                 let rhs_expr = rust.expression_stack.pop().unwrap();
+//                 let lhs_expr = rust.expression_stack.pop().unwrap();
+//                 rust.delay_expr(format!("({})-({})", lhs_expr, rhs_expr));
+//             }
+//             Command::Dot(rhs_field) => {
+//                 let lhs_expr = rust.expression_stack.pop().unwrap();
+//                 rust.delay_expr(format!("({}).{}", lhs_expr, rhs_field));
+//             }
+//             Command::Call(def_id) => {
+//                 if let Definition::Fn(target) = &c.definitions[*def_id] {
+//                     let mut args_expr = String::new();
+//                     let mut after_first = false;
+//                     for _ in 0..target.params.len() {
+//                         if after_first {
+//                             args_expr = ", ".to_string() + &args_expr;
+//                         } else {
+//                             after_first = true;
+//                         }
 
-                        let arg_expr = rust.expression_stack.pop().unwrap();
-                        args_expr = arg_expr + &args_expr;
-                    }
+//                         let arg_expr = rust.expression_stack.pop().unwrap();
+//                         args_expr = arg_expr + &args_expr;
+//                     }
 
-                    rust.delay_expr(format!("{}({})", target.name, args_expr));
-                } else if let Definition::BuiltinFn(builtin_fn) = &c.definitions[*def_id] {
-                    match builtin_fn {
-                        BuiltinFn::StringInterpolate => {
-                            let format_string = rust.expression_stack.pop().unwrap();
+//                     rust.delay_expr(format!("{}({})", target.name, args_expr));
+//                 } else if let Definition::BuiltinFn(builtin_fn) = &c.definitions[*def_id] {
+//                     match builtin_fn {
+//                         BuiltinFn::StringInterpolate => {
+//                             let format_string = rust.expression_stack.pop().unwrap();
 
-                            let num_args = format_string.matches("{}").count();
+//                             let num_args = format_string.matches("{}").count();
 
-                            let mut args_expr = String::new();
-                            let mut after_first = false;
-                            for _ in 0..num_args {
-                                if after_first {
-                                    args_expr = ", ".to_string() + &args_expr;
-                                } else {
-                                    after_first = true;
-                                }
+//                             let mut args_expr = String::new();
+//                             let mut after_first = false;
+//                             for _ in 0..num_args {
+//                                 if after_first {
+//                                     args_expr = ", ".to_string() + &args_expr;
+//                                 } else {
+//                                     after_first = true;
+//                                 }
 
-                                let arg_expr = rust.expression_stack.pop().unwrap();
-                                args_expr = arg_expr + &args_expr;
-                            }
-                            rust.delay_expr(format!("format!({}, {})", format_string, args_expr));
-                        }
-                    }
-                } else if let Definition::Struct(s) = &c.definitions[*def_id] {
-                    let mut field_values = vec![];
-                    for _ in 0..s.fields.len() {
-                        field_values.push(rust.expression_stack.pop().unwrap());
-                    }
+//                                 let arg_expr = rust.expression_stack.pop().unwrap();
+//                                 args_expr = arg_expr + &args_expr;
+//                             }
+//                             rust.delay_expr(format!("format!({}, {})", format_string, args_expr));
+//                         }
+//                     }
+//                 } else if let Definition::Struct(s) = &c.definitions[*def_id] {
+//                     let mut field_values = vec![];
+//                     for _ in 0..s.fields.len() {
+//                         field_values.push(rust.expression_stack.pop().unwrap());
+//                     }
 
-                    let mut struct_expr = String::new();
+//                     let mut struct_expr = String::new();
 
-                    struct_expr += &format!("{} {{", s.name);
-                    for field in &s.fields {
-                        struct_expr += &format!("{}: {},", field.name, field_values.pop().unwrap());
-                    }
-                    struct_expr += "} ";
-                    rust.delay_expr(struct_expr);
-                } else {
-                    unimplemented!("Only calls to functions are currently supported)");
-                }
-            }
-            Command::ReturnLastStackValue => {
-                let ret_val = rust.expression_stack.pop().unwrap();
-                rust.output_raw(&format!("return {};\n", ret_val));
-            }
-            Command::DebugPrint => {
-                let print_val = rust.expression_stack.pop().unwrap();
-                rust.output_raw(&format!("println!(\"{{:?}}\", {});\n", print_val));
-            }
-        }
-    }
+//                     struct_expr += &format!("{} {{", s.name);
+//                     for field in &s.fields {
+//                         struct_expr += &format!("{}: {},", field.name, field_values.pop().unwrap());
+//                     }
+//                     struct_expr += "} ";
+//                     rust.delay_expr(struct_expr);
+//                 } else {
+//                     unimplemented!("Only calls to functions are currently supported)");
+//                 }
+//             }
+//             Command::ReturnLastStackValue => {
+//                 let ret_val = rust.expression_stack.pop().unwrap();
+//                 rust.output_raw(&format!("return {};\n", ret_val));
+//             }
+//             Command::DebugPrint => {
+//                 let print_val = rust.expression_stack.pop().unwrap();
+//                 rust.output_raw(&format!("println!(\"{{:?}}\", {});\n", print_val));
+//             }
+//         }
+//     }
 
-    if rust.expression_stack.len() > 0 {
-        let final_expr = rust.expression_stack.pop().unwrap();
-        rust.output_raw(&format!("{};\n", final_expr));
-    }
+//     if rust.expression_stack.len() > 0 {
+//         let final_expr = rust.expression_stack.pop().unwrap();
+//         rust.output_raw(&format!("{};\n", final_expr));
+//     }
 
-    assert_eq!(rust.expression_stack.len(), 0);
-    rust.output_raw("}\n");
-}
+//     assert_eq!(rust.expression_stack.len(), 0);
+//     rust.output_raw("}\n");
+// }
 
-fn codegen_struct(rust: &mut RustFile, c: &Context, s: &Struct) {
-    rust.output_raw(&format!("#[derive(Debug)]\n"));
-    rust.output_raw(&format!("struct {} {{\n", s.name));
-    for field in &s.fields {
-        rust.output_raw(&format!("{}: {},\n", field.name, codegen_type(c, field.ty)));
-    }
-    rust.output_raw("}\n");
-}
+// fn codegen_struct(rust: &mut RustFile, c: &Context, s: &Struct) {
+//     rust.output_raw(&format!("#[derive(Debug)]\n"));
+//     rust.output_raw(&format!("struct {} {{\n", s.name));
+//     for field in &s.fields {
+//         rust.output_raw(&format!("{}: {},\n", field.name, codegen_type(c, field.ty)));
+//     }
+//     rust.output_raw("}\n");
+// }
 
-//FIXME: there are more efficient ways to build strings than this
-pub fn codegen(rust: &mut RustFile, c: &Context) {
-    for definition in &c.definitions {
-        match definition {
-            Definition::Fn(f) => {
-                codegen_fn(rust, c, f);
-            }
-            Definition::Struct(s) => {
-                codegen_struct(rust, c, s);
-            }
-            _ => {}
-        }
-    }
-}
+// //FIXME: there are more efficient ways to build strings than this
+// pub fn codegen(rust: &mut RustFile, c: &Context) {
+//     for definition in &c.definitions {
+//         match definition {
+//             Definition::Fn(f) => {
+//                 codegen_fn(rust, c, f);
+//             }
+//             Definition::Struct(s) => {
+//                 codegen_struct(rust, c, s);
+//             }
+//             _ => {}
+//         }
+//     }
+// }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,7 +1,7 @@
-#![allow(unused_mut)]
-#![allow(unused_variables)]
-
-use crate::ir::{builtin_type, BuiltinFn, Command, Context, DefId, Definition, Function, Struct};
+use crate::ir::{
+    builtin_type, BinOp, BuiltinFn, Context, DefId, Definition, Function, Operand, Place, Rvalue,
+    Statement, StatementKind,
+};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -30,149 +30,136 @@ impl fmt::Display for Value {
     }
 }
 
-pub struct Eval {
-    pub stack: Vec<Value>,
+#[derive(Debug)]
+pub struct CallFrame {
+    locals: Vec<Value>,
 }
 
-impl Eval {
-    pub fn new() -> Eval {
-        Eval { stack: vec![] }
+impl CallFrame {
+    fn new() -> CallFrame {
+        CallFrame { locals: vec![] }
     }
+}
 
-    pub fn eval_block(
-        &mut self,
-        c: &Context,
-        vars: &mut HashMap<usize, usize>,
-        commands: &Vec<Command>,
-    ) -> Value {
-        for command in commands {
-            match command {
-                Command::ConstInt(i) => self.stack.push(Value::I32(*i)),
-                Command::ConstString(s) => self.stack.push(Value::Str(s.clone())),
-                Command::Add => {
-                    let rhs = self.stack.pop().unwrap();
-                    let lhs = self.stack.pop().unwrap();
-                    match (lhs, rhs) {
-                        (Value::I32(l), Value::I32(r)) => {
-                            self.stack.push(Value::I32(l + r));
-                        }
-                        _ => unimplemented!("Unsupported add of non-integers"),
-                    }
+pub fn eval_operand(_context: &Context, frame: &mut CallFrame, operand: &Operand) -> Value {
+    match operand {
+        Operand::ConstantInt(i) => Value::I32(*i),
+        Operand::ConstantString(s) => Value::Str(s.clone()),
+        Operand::Move(m) => match m {
+            Place::Local(source_var_id) => frame.locals[*source_var_id].clone(),
+            Place::Static(_) => unimplemented!("Moving from static data not currently supported"),
+        },
+        Operand::Copy(m) => match m {
+            Place::Local(source_var_id) => frame.locals[*source_var_id].clone(),
+            Place::Static(_) => unimplemented!("Moving from static data not currently supported"),
+        },
+    }
+}
+
+pub fn eval_stmt(context: &Context, frame: &mut CallFrame, stmt: &Statement) {
+    match &stmt.kind {
+        StatementKind::Assign(place, rvalue) => match place {
+            Place::Local(target_var_id) => match rvalue {
+                Rvalue::Use(ref operand) => {
+                    frame.locals[*target_var_id] = eval_operand(context, frame, operand)
                 }
-                Command::Sub => {
-                    let rhs = self.stack.pop().unwrap();
-                    let lhs = self.stack.pop().unwrap();
-                    match (lhs, rhs) {
-                        (Value::I32(l), Value::I32(r)) => {
-                            self.stack.push(Value::I32(l - r));
-                        }
-                        _ => unimplemented!("Unsupported subtract of non-integers"),
-                    }
-                }
-                Command::DebugPrint => {
-                    let arg = self.stack.pop().unwrap();
-
-                    println!("{}", arg);
-                }
-                Command::VarUse(var_id) => {
-                    let stack_pos = vars[var_id];
-                    let var_use = self.stack[stack_pos].clone();
-                    self.stack.push(var_use);
-                }
-                Command::VarDeclWithInit(var_id) => {
-                    vars.insert(*var_id, self.stack.len() - 1);
-                }
-                Command::Call(def_id) => match &c.definitions[*def_id] {
-                    Definition::Fn(ref f) => {
-                        let result = self.eval_fn(c, f);
-                        self.stack.push(result);
-                    }
-                    Definition::Struct(ref s) => {
-                        let mut new_obj = HashMap::new();
-                        for field in s.fields.iter().rev() {
-                            let val = self.stack.pop().unwrap();
-                            new_obj.insert(field.name.clone(), val);
-                        }
-                        self.stack.push(Value::Struct(new_obj));
-                    }
-                    Definition::BuiltinFn(BuiltinFn::StringInterpolate) => {
-                        let format_string = self.stack.pop().unwrap();
-
-                        match format_string {
-                            Value::Str(s) => {
-                                let sections: Vec<&str> = s.split("{}").collect();
-                                let sections_len = sections.len();
-
-                                let mut result = String::new();
-                                let mut pos = 0;
-
-                                for i in 0..(sections_len - 1) {
-                                    result += sections[i];
-                                    result += &format!(
-                                        "{}",
-                                        self.stack[self.stack.len() - sections_len + i]
-                                    );
-                                }
-
-                                result += sections[sections_len - 1];
-
-                                for _ in 0..sections_len {
-                                    self.stack.pop();
-                                }
-
-                                self.stack.push(Value::Str(result));
+                Rvalue::Call(def_id, args) => {
+                    match &context.definitions[*def_id] {
+                        Definition::Fn(f) => {
+                            let mut new_frame = CallFrame::new();
+                            new_frame.locals.push(Value::Void); // return value
+                            for arg in args {
+                                new_frame.locals.push(eval_operand(context, frame, arg));
                             }
-                            _ => unimplemented!("String interpolation without a format string"),
+                            let num_temps = f.local_decls.len() - 1 - f.arg_count;
+                            for _ in 0..num_temps {
+                                new_frame.locals.push(Value::Void);
+                            }
+                            eval_fn(context, &mut new_frame, f);
+                            let result = new_frame.locals[0].clone();
+                            frame.locals[*target_var_id] = result;
                         }
-                    }
-                    x => unimplemented!("Call of a non-function: {:#?}", x),
-                },
-                Command::ReturnLastStackValue => {
-                    let result = self.stack.pop().unwrap();
-                    return result;
-                }
-                Command::Dot(field) => {
-                    let lhs = self.stack.pop().unwrap();
-                    match lhs {
-                        Value::Struct(s) => {
-                            self.stack.push(s[field].clone());
+                        Definition::BuiltinFn(BuiltinFn::StringInterpolate) => {
+                            let mut arg_eval = vec![];
+                            for arg in args {
+                                arg_eval.push(eval_operand(context, frame, arg));
+                            }
+
+                            let format_string = &arg_eval[0];
+
+                            match format_string {
+                                Value::Str(s) => {
+                                    let sections: Vec<&str> = s.split("{}").collect();
+                                    let sections_len = sections.len();
+
+                                    let mut result = String::new();
+
+                                    for i in 0..(sections_len - 1) {
+                                        result += sections[i];
+                                        result += &format!("{}", arg_eval[i + 1]);
+                                    }
+
+                                    result += sections[sections_len - 1];
+
+                                    frame.locals[*target_var_id] = Value::Str(result);
+                                }
+                                _ => unimplemented!("String interpolation without a format string"),
+                            }
                         }
-                        _ => unimplemented!("Dot into non-struct value")
+                        _ => unimplemented!("Unsupported call of non-function"),
                     }
                 }
-                //_ => unimplemented!("Incomplete eval of commands in eval_fn"),
-            }
-        }
+                Rvalue::BinaryOp(bin_op, lhs_var_id, rhs_var_id) => {
+                    let lhs = &frame.locals[*lhs_var_id];
+                    let rhs = &frame.locals[*rhs_var_id];
 
-        Value::Void
-    }
-
-    pub fn eval_fn(&mut self, c: &Context, f: &Function) -> Value {
-        let mut vars = HashMap::new();
-
-        //Rather than popping the values only to push them back on so the
-        //function body can see it, let's instead capture where the arguments are in the stack
-        //by setting up the function's variables ahead of processing the body
-        let mut offset = 0;
-        let param_len = f.params.len();
-        for param in &f.params {
-            vars.insert(param.var_id, self.stack.len() - param_len + offset);
-            offset += 1;
-        }
-
-        self.eval_block(c, &mut vars, &f.body)
-    }
-
-    pub fn eval(&mut self, c: &Context) {
-        for definition in &c.definitions {
-            match definition {
-                Definition::Fn(f) => {
-                    if f.name == "main" {
-                        self.eval_fn(c, f);
+                    match bin_op {
+                        BinOp::Add => match (lhs, rhs) {
+                            (Value::I32(lhs_i32), Value::I32(rhs_i32)) => {
+                                frame.locals[*target_var_id] = Value::I32(lhs_i32 + rhs_i32);
+                            }
+                            _ => unimplemented!("Unsupported add of non-integers"),
+                        },
+                        BinOp::Sub => match (lhs, rhs) {
+                            (Value::I32(lhs_i32), Value::I32(rhs_i32)) => {
+                                frame.locals[*target_var_id] = Value::I32(lhs_i32 - rhs_i32);
+                            }
+                            _ => unimplemented!("Unsupported add of non-integers"),
+                        },
                     }
                 }
-                _ => {}
+            },
+            Place::Static(_) => unimplemented!("Assigning into static currently not supported"),
+        },
+        StatementKind::DebugPrint(place) => match place {
+            Place::Local(var_id) => {
+                println!("{}", frame.locals[*var_id]);
             }
+            Place::Static(_) => unimplemented!("Debug print of value other than local variable"),
+        },
+    }
+}
+
+pub fn eval_fn(context: &Context, frame: &mut CallFrame, fun: &Function) {
+    for block in &fun.basic_blocks {
+        for stmt in &block.statements {
+            eval_stmt(context, frame, stmt);
         }
+    }
+}
+
+pub fn eval_context(context: &Context, starting_fn: DefId) {
+    match context.definitions[starting_fn] {
+        Definition::Fn(ref f) => {
+            let mut frame = CallFrame::new();
+            let num_temps = f.local_decls.len() - 1 - f.arg_count;
+            frame.locals.push(Value::Void); // return value
+            for _ in 0..num_temps {
+                frame.locals.push(Value::Void);
+            }
+
+            eval_fn(context, &mut frame, f);
+        }
+        _ => unimplemented!("Starting function is not a function definition"),
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -48,94 +48,127 @@ pub fn eval_operand(_context: &Context, frame: &mut CallFrame, operand: &Operand
         Operand::Move(m) => match m {
             Place::Local(source_var_id) => frame.locals[*source_var_id].clone(),
             Place::Static(_) => unimplemented!("Moving from static data not currently supported"),
+            Place::Field(source_var_id, field_name) => match &frame.locals[*source_var_id] {
+                Value::Struct(s) => s[field_name].clone(),
+                _ => unimplemented!("Field access of non-struct value"),
+            },
         },
         Operand::Copy(m) => match m {
             Place::Local(source_var_id) => frame.locals[*source_var_id].clone(),
             Place::Static(_) => unimplemented!("Moving from static data not currently supported"),
+            Place::Field(source_var_id, field_name) => match &frame.locals[*source_var_id] {
+                Value::Struct(s) => s[field_name].clone(),
+                _ => unimplemented!("Field access of non-struct value"),
+            },
         },
+    }
+}
+
+fn eval_rvalue(context: &Context, frame: &mut CallFrame, rvalue: &Rvalue) -> Value {
+    match rvalue {
+        Rvalue::Use(ref operand) => eval_operand(context, frame, operand),
+        Rvalue::Call(def_id, args) => {
+            match &context.definitions[*def_id] {
+                Definition::Fn(f) => {
+                    let mut new_frame = CallFrame::new();
+                    new_frame.locals.push(Value::Void); // return value
+                    for arg in args {
+                        new_frame.locals.push(eval_operand(context, frame, arg));
+                    }
+                    let num_temps = f.local_decls.len() - 1 - f.arg_count;
+                    for _ in 0..num_temps {
+                        new_frame.locals.push(Value::Void);
+                    }
+                    eval_fn(context, &mut new_frame, f);
+                    let result = new_frame.locals[0].clone();
+                    result
+                }
+                Definition::BuiltinFn(BuiltinFn::StringInterpolate) => {
+                    let mut arg_eval = vec![];
+                    for arg in args {
+                        arg_eval.push(eval_operand(context, frame, arg));
+                    }
+
+                    let format_string = &arg_eval[0];
+
+                    match format_string {
+                        Value::Str(s) => {
+                            let sections: Vec<&str> = s.split("{}").collect();
+                            let sections_len = sections.len();
+
+                            let mut result = String::new();
+
+                            for i in 0..(sections_len - 1) {
+                                result += sections[i];
+                                result += &format!("{}", arg_eval[i + 1]);
+                            }
+
+                            result += sections[sections_len - 1];
+
+                            Value::Str(result)
+                        }
+                        _ => unimplemented!("String interpolation without a format string"),
+                    }
+                }
+                Definition::Struct(ref s) => {
+                    let mut new_obj = HashMap::new();
+                    for i in 0..s.fields.len() {
+                        new_obj.insert(
+                            s.fields[i].name.clone(),
+                            eval_operand(context, frame, &args[i]),
+                        );
+                    }
+                    Value::Struct(new_obj)
+                }
+                _ => unimplemented!("Unsupported call of non-function"),
+            }
+        }
+        Rvalue::BinaryOp(bin_op, lhs_var_id, rhs_var_id) => {
+            let lhs = &frame.locals[*lhs_var_id];
+            let rhs = &frame.locals[*rhs_var_id];
+
+            match bin_op {
+                BinOp::Add => match (lhs, rhs) {
+                    (Value::I32(lhs_i32), Value::I32(rhs_i32)) => Value::I32(lhs_i32 + rhs_i32),
+                    _ => unimplemented!("Unsupported add of non-integers"),
+                },
+                BinOp::Sub => match (lhs, rhs) {
+                    (Value::I32(lhs_i32), Value::I32(rhs_i32)) => Value::I32(lhs_i32 - rhs_i32),
+                    _ => unimplemented!("Unsupported add of non-integers"),
+                },
+            }
+        }
     }
 }
 
 pub fn eval_stmt(context: &Context, frame: &mut CallFrame, stmt: &Statement) {
     match &stmt.kind {
-        StatementKind::Assign(place, rvalue) => match place {
-            Place::Local(target_var_id) => match rvalue {
-                Rvalue::Use(ref operand) => {
-                    frame.locals[*target_var_id] = eval_operand(context, frame, operand)
-                }
-                Rvalue::Call(def_id, args) => {
-                    match &context.definitions[*def_id] {
-                        Definition::Fn(f) => {
-                            let mut new_frame = CallFrame::new();
-                            new_frame.locals.push(Value::Void); // return value
-                            for arg in args {
-                                new_frame.locals.push(eval_operand(context, frame, arg));
-                            }
-                            let num_temps = f.local_decls.len() - 1 - f.arg_count;
-                            for _ in 0..num_temps {
-                                new_frame.locals.push(Value::Void);
-                            }
-                            eval_fn(context, &mut new_frame, f);
-                            let result = new_frame.locals[0].clone();
-                            frame.locals[*target_var_id] = result;
+        StatementKind::Assign(place, rvalue) => {
+            let rval = eval_rvalue(context, frame, rvalue);
+            match place {
+                Place::Local(target_var_id) => frame.locals[*target_var_id] = rval,
+                Place::Static(_) => unimplemented!("Assigning into static currently not supported"),
+                Place::Field(source_var_id, field_name) => {
+                    match &mut frame.locals[*source_var_id] {
+                        Value::Struct(s) => {
+                            let _ = s.insert(field_name.clone(), rval);
                         }
-                        Definition::BuiltinFn(BuiltinFn::StringInterpolate) => {
-                            let mut arg_eval = vec![];
-                            for arg in args {
-                                arg_eval.push(eval_operand(context, frame, arg));
-                            }
-
-                            let format_string = &arg_eval[0];
-
-                            match format_string {
-                                Value::Str(s) => {
-                                    let sections: Vec<&str> = s.split("{}").collect();
-                                    let sections_len = sections.len();
-
-                                    let mut result = String::new();
-
-                                    for i in 0..(sections_len - 1) {
-                                        result += sections[i];
-                                        result += &format!("{}", arg_eval[i + 1]);
-                                    }
-
-                                    result += sections[sections_len - 1];
-
-                                    frame.locals[*target_var_id] = Value::Str(result);
-                                }
-                                _ => unimplemented!("String interpolation without a format string"),
-                            }
-                        }
-                        _ => unimplemented!("Unsupported call of non-function"),
+                        _ => unimplemented!("Field access of non-struct value"),
                     }
                 }
-                Rvalue::BinaryOp(bin_op, lhs_var_id, rhs_var_id) => {
-                    let lhs = &frame.locals[*lhs_var_id];
-                    let rhs = &frame.locals[*rhs_var_id];
-
-                    match bin_op {
-                        BinOp::Add => match (lhs, rhs) {
-                            (Value::I32(lhs_i32), Value::I32(rhs_i32)) => {
-                                frame.locals[*target_var_id] = Value::I32(lhs_i32 + rhs_i32);
-                            }
-                            _ => unimplemented!("Unsupported add of non-integers"),
-                        },
-                        BinOp::Sub => match (lhs, rhs) {
-                            (Value::I32(lhs_i32), Value::I32(rhs_i32)) => {
-                                frame.locals[*target_var_id] = Value::I32(lhs_i32 - rhs_i32);
-                            }
-                            _ => unimplemented!("Unsupported add of non-integers"),
-                        },
-                    }
-                }
-            },
-            Place::Static(_) => unimplemented!("Assigning into static currently not supported"),
-        },
+            }
+        }
         StatementKind::DebugPrint(place) => match place {
             Place::Local(var_id) => {
                 println!("{}", frame.locals[*var_id]);
             }
             Place::Static(_) => unimplemented!("Debug print of value other than local variable"),
+            Place::Field(source_var_id, field_name) => match &frame.locals[*source_var_id] {
+                Value::Struct(s) => {
+                    println!("{}", s[field_name]);
+                }
+                _ => unimplemented!("Field access of non-struct value"),
+            },
         },
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,8 +1,14 @@
 pub type DefId = usize;
 pub type VarId = usize;
 
+use crate::ty::{BaseKind, Perm, Ty};
+
 #[derive(Debug)]
 pub struct SourceInfo;
+
+fn create_simple_ty(def_id: DefId) -> Ty {
+    Ty { perm: Perm }
+}
 
 //Lark MIR representation of a single function
 #[derive(Debug)]
@@ -41,6 +47,32 @@ impl Function {
     pub fn push_block(&mut self, block: BasicBlock) {
         self.basic_blocks.push(block);
     }
+}
+
+#[derive(Debug)]
+pub struct Struct {
+    pub fields: Vec<Field>,
+    pub name: String,
+}
+
+impl Struct {
+    pub fn field(mut self, name: String, ty: DefId) -> Self {
+        self.fields.push(Field { ty, name });
+        self
+    }
+
+    pub fn new(name: String) -> Self {
+        Struct {
+            name,
+            fields: vec![],
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Field {
+    ty: DefId,
+    name: String,
 }
 
 #[derive(Debug)]

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -7,21 +7,21 @@ pub struct SourceInfo;
 //Lark MIR representation of a single function
 #[derive(Debug)]
 pub struct Function {
-    basic_blocks: Vec<BasicBlock>,
+    pub basic_blocks: Vec<BasicBlock>,
 
     //First local = return value pointer
     //Followed by arg_count parameters to the function
     //Followed by user defined variables and temporaries
-    local_decls: Vec<LocalDecl>,
+    pub local_decls: Vec<LocalDecl>,
 
-    arg_count: usize,
+    pub arg_count: usize,
 }
 
 impl Function {
-    pub fn new(return_ty: DefId, args: Vec<LocalDecl>) -> Function {
+    pub fn new(return_ty: DefId, mut args: Vec<LocalDecl>) -> Function {
+        let arg_count = args.len();
         let mut local_decls = vec![LocalDecl::new_return_place(return_ty)];
         local_decls.append(&mut args);
-        let arg_count = local_decls.len();
 
         Function {
             basic_blocks: vec![],
@@ -78,7 +78,7 @@ pub struct Statement {
 #[derive(Debug)]
 pub enum StatementKind {
     Assign(Place, Rvalue),
-    DebugPrint(Rvalue),
+    DebugPrint(Place),
 }
 
 #[derive(Debug)]
@@ -102,14 +102,14 @@ pub enum Place {
 pub enum Rvalue {
     Use(Operand),
     BinaryOp(BinOp, VarId, VarId),
+    //FIXME: MIR has this as a Terminator, presumably because stack can unwind
+    Call(DefId, Vec<Operand>),
 }
 
 #[derive(Debug)]
 pub enum Operand {
     Copy(Place),
     Move(Place),
-    //FIXME: MIR has this as a Terminator, presumably because stack can unwind
-    Call(DefId, Vec<Operand>),
     //FIXME: Move to Box<Constant>
     ConstantInt(i32),
     ConstantString(String),
@@ -165,6 +165,7 @@ pub enum Definition {
     Fn(Function),
 }
 
+#[derive(Debug)]
 pub struct Context {
     pub definitions: Vec<Definition>,
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -15,10 +15,12 @@ pub struct Function {
     pub local_decls: Vec<LocalDecl>,
 
     pub arg_count: usize,
+
+    pub name: String,
 }
 
 impl Function {
-    pub fn new(return_ty: DefId, mut args: Vec<LocalDecl>) -> Function {
+    pub fn new(return_ty: DefId, mut args: Vec<LocalDecl>, name: String) -> Function {
         let arg_count = args.len();
         let mut local_decls = vec![LocalDecl::new_return_place(return_ty)];
         local_decls.append(&mut args);
@@ -27,6 +29,7 @@ impl Function {
             basic_blocks: vec![],
             local_decls,
             arg_count,
+            name,
         }
     }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -2,6 +2,201 @@ pub type DefId = usize;
 pub type VarId = usize;
 
 #[derive(Debug)]
+pub struct SourceInfo;
+
+//Lark MIR representation of a single function
+#[derive(Debug)]
+pub struct Function {
+    basic_blocks: Vec<BasicBlock>,
+
+    //First local = return value pointer
+    //Followed by arg_count parameters to the function
+    //Followed by user defined variables and temporaries
+    local_decls: Vec<LocalDecl>,
+
+    arg_count: usize,
+}
+
+impl Function {
+    pub fn new(return_ty: DefId, args: Vec<LocalDecl>) -> Function {
+        let mut local_decls = vec![LocalDecl::new_return_place(return_ty)];
+        local_decls.append(&mut args);
+        let arg_count = local_decls.len();
+
+        Function {
+            basic_blocks: vec![],
+            local_decls,
+            arg_count,
+        }
+    }
+
+    pub fn new_temp(&mut self, ty: DefId) -> VarId {
+        self.local_decls.push(LocalDecl::new_temp(ty));
+        self.local_decls.len() - 1
+    }
+
+    pub fn push_block(&mut self, block: BasicBlock) {
+        self.basic_blocks.push(block);
+    }
+}
+
+#[derive(Debug)]
+pub struct BasicBlock {
+    pub statements: Vec<Statement>,
+    pub terminator: Option<Terminator>,
+}
+
+impl BasicBlock {
+    pub fn new() -> BasicBlock {
+        BasicBlock {
+            statements: vec![],
+            terminator: None,
+        }
+    }
+
+    pub fn push_stmt(&mut self, kind: StatementKind) {
+        self.statements.push(Statement {
+            source_info: SourceInfo,
+            kind,
+        });
+    }
+
+    pub fn terminate(&mut self, terminator_kind: TerminatorKind) {
+        self.terminator = Some(Terminator {
+            source_info: SourceInfo,
+            kind: terminator_kind,
+        });
+    }
+}
+
+#[derive(Debug)]
+pub struct Statement {
+    pub source_info: SourceInfo,
+    pub kind: StatementKind,
+}
+
+#[derive(Debug)]
+pub enum StatementKind {
+    Assign(Place, Rvalue),
+    DebugPrint(Rvalue),
+}
+
+#[derive(Debug)]
+pub struct Terminator {
+    pub source_info: SourceInfo,
+    pub kind: TerminatorKind,
+}
+
+#[derive(Debug)]
+pub enum TerminatorKind {
+    Return,
+}
+
+#[derive(Debug)]
+pub enum Place {
+    Local(VarId),
+    Static(DefId),
+}
+
+#[derive(Debug)]
+pub enum Rvalue {
+    Use(Operand),
+    BinaryOp(BinOp, VarId, VarId),
+}
+
+#[derive(Debug)]
+pub enum Operand {
+    Copy(Place),
+    Move(Place),
+    //FIXME: MIR has this as a Terminator, presumably because stack can unwind
+    Call(DefId, Vec<Operand>),
+    //FIXME: Move to Box<Constant>
+    ConstantInt(i32),
+    ConstantString(String),
+}
+
+#[derive(Debug)]
+pub enum BinOp {
+    Add,
+    Sub,
+}
+
+#[derive(Debug)]
+pub struct LocalDecl {
+    pub ty: DefId,
+    pub name: Option<String>,
+}
+
+impl LocalDecl {
+    pub fn new_return_place(return_ty: DefId) -> LocalDecl {
+        LocalDecl {
+            ty: return_ty,
+            name: None,
+        }
+    }
+
+    pub fn new_temp(ty: DefId) -> LocalDecl {
+        LocalDecl { ty, name: None }
+    }
+
+    pub fn new(ty: DefId, name: Option<String>) -> LocalDecl {
+        LocalDecl { ty, name }
+    }
+}
+
+pub mod builtin_type {
+    #[allow(unused)]
+    pub const UNKNOWN: usize = 0;
+    pub const VOID: usize = 1;
+    pub const I32: usize = 2;
+    pub const STRING: usize = 3;
+    pub const ERROR: usize = 100;
+}
+
+#[derive(Debug)]
+pub enum BuiltinFn {
+    StringInterpolate,
+}
+
+#[derive(Debug)]
+pub enum Definition {
+    Builtin,
+    BuiltinFn(BuiltinFn),
+    Fn(Function),
+}
+
+pub struct Context {
+    pub definitions: Vec<Definition>,
+}
+
+impl Context {
+    pub fn new() -> Context {
+        let mut definitions = vec![];
+
+        for _ in 0..(builtin_type::ERROR + 1) {
+            definitions.push(Definition::Builtin); // UNKNOWN
+        }
+
+        definitions.push(Definition::BuiltinFn(BuiltinFn::StringInterpolate));
+
+        Context { definitions }
+    }
+
+    pub fn add_definition(&mut self, def: Definition) -> usize {
+        self.definitions.push(def);
+        self.definitions.len() - 1
+    }
+}
+
+/*
+use indexed_vec::{newtype_index, IndexVec};
+
+pub type DefId = usize;
+pub type VarId = usize;
+
+struct BasicBlock;
+
+#[derive(Debug)]
 pub struct Variable {
     pub ty: DefId,
     pub name: String,
@@ -127,3 +322,4 @@ impl Context {
         self.definitions.len() - 1
     }
 }
+*/

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,86 @@ mod ty;
 
 use crate::codegen::{codegen, RustFile};
 use crate::eval::Eval;
-use crate::ir::{builtin_type, Command, Context, Definition, Function, Struct};
+use crate::ir::{
+    builtin_type, BasicBlock, BinOp, Context, Definition, Function, LocalDecl, Operand, Place,
+    Rvalue, StatementKind, TerminatorKind,
+};
 
 fn main() {
     let mut c = Context::new();
 
+    let mut bob = Function::new(
+        builtin_type::I32,
+        vec![
+            LocalDecl::new(builtin_type::I32, Some("x".into())),
+            LocalDecl::new(builtin_type::I32, Some("y".into())),
+        ],
+    );
+
+    let bob_tmp = bob.new_temp(builtin_type::I32);
+
+    let mut bb1 = BasicBlock::new();
+
+    bb1.push_stmt(StatementKind::Assign(
+        Place::Local(bob_tmp),
+        Rvalue::BinaryOp(BinOp::Sub, 1, 2),
+    ));
+    bb1.push_stmt(StatementKind::Assign(
+        Place::Local(0),
+        Rvalue::Use(Operand::Move(Place::Local(bob_tmp))),
+    ));
+
+    bb1.terminate(TerminatorKind::Return);
+
+    bob.push_block(bb1);
+
+    let bob_def_id = c.add_definition(Definition::Fn(bob));
+
+    // bob.body.push(Command::VarUse(0));
+    // bob.body.push(Command::VarUse(1));
+    // bob.body.push(Command::Sub);
+    // bob.body.push(Command::VarDeclWithInit(2));
+    // bob.body.push(Command::VarUse(2));
+    // bob.body.push(Command::ReturnLastStackValue);
+
+    let mut m = Function::new(builtin_type::VOID, vec![]);
+    let call_result_tmp = m.new_temp(builtin_type::I32);
+    let interp_result_tmp = m.new_temp(builtin_type::STRING);
+
+    let mut bb2 = BasicBlock::new();
+
+    bb2.push_stmt(StatementKind::Assign(
+        Place::Local(call_result_tmp),
+        Rvalue::Use(Operand::Call(
+            bob_def_id,
+            vec![Operand::ConstantInt(11), Operand::ConstantInt(8)],
+        )),
+    ));
+
+    bb2.push_stmt(StatementKind::Assign(
+        Place::Local(interp_result_tmp),
+        Rvalue::Use(Operand::Call(
+            101, /*builtin string interp*/
+            vec![
+                Operand::ConstantString("Hello, world {}".into()),
+                Operand::Move(Place::Local(call_result_tmp)),
+            ],
+        )),
+    ));
+
+    bb2.push_stmt(StatementKind::DebugPrint(Rvalue::Use(Operand::Move(
+        Place::Local(interp_result_tmp),
+    ))));
+
+    // let mut m = Function::new("main".into(), builtin_type::VOID);
+    // m.body.push(Command::ConstInt(11));
+    // m.body.push(Command::ConstInt(8));
+    // m.body.push(Command::Call(bob_def_id));
+    // m.body.push(Command::ConstString("Hello, world {}".into()));
+    // m.body.push(Command::Call(101)); //built-in string interpolation
+    // m.body.push(Command::DebugPrint);
+
+    /*
     let mut bob = Function::new("bob".into(), builtin_type::I32)
         .param("x".into(), builtin_type::I32)
         .param("y".into(), builtin_type::I32);
@@ -69,6 +144,7 @@ fn main() {
     m.body.push(Command::DebugPrint);
 
     c.definitions.push(Definition::Fn(m));
+    */
 
     let mut rust = RustFile::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod ir;
 mod parser;
 mod ty;
 
-//use crate::codegen::{codegen, RustFile};
+use crate::codegen::{codegen, RustFile};
 use crate::eval::eval_context;
 use crate::ir::{
     builtin_type, BasicBlock, BinOp, Context, Definition, Function, LocalDecl, Operand, Place,
@@ -39,6 +39,7 @@ fn main() {
             LocalDecl::new(builtin_type::I32, Some("x".into())),
             LocalDecl::new(builtin_type::I32, Some("y".into())),
         ],
+        "bob".into(),
     );
 
     let bob_tmp = bob.new_temp(builtin_type::I32);
@@ -60,7 +61,7 @@ fn main() {
 
     let bob_def_id = c.add_definition(Definition::Fn(bob));
 
-    let mut m = Function::new(builtin_type::VOID, vec![]);
+    let mut m = Function::new(builtin_type::VOID, vec![], "main".into());
     let call_result_tmp = m.new_temp(builtin_type::I32);
     let interp_result_tmp = m.new_temp(builtin_type::STRING);
 
@@ -91,10 +92,10 @@ fn main() {
     m.push_block(bb2);
     let main_def_id = c.add_definition(Definition::Fn(m));
 
-    //let mut rust = RustFile::new();
+    let mut rust = RustFile::new();
 
-    // codegen(&mut rust, &c);
-    // println!("{}", rust.render());
+    codegen(&mut rust, &c);
+    println!("{}", rust.render());
 
     //let mut eval = Eval::new();
     //eval.eval(&c);

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -13,8 +13,8 @@ crate mod unify;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 crate struct Ty {
-    perm: Perm,
-    base: Base,
+    crate perm: Perm,
+    crate base: Base,
 }
 
 index_type! {


### PR DESCRIPTION
This moves the IR to MIR. It should have parity with the previous IR, which support functions, function calls, structs, and struct inits.

I've also gone ahead and adapted to using the Ty struct from the on-going type system work.