### PR TITLE
more-or-less complete sketch for query system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,19 @@ mod lexer;
 #[macro_use]
 mod indices;
 
+#[macro_use]
+mod query;
+
 mod codegen;
 mod eval;
 mod hir;
 mod intern;
 mod ir;
 mod parser;
+mod query_impl;
 mod ty;
 mod typeck;
+mod unify;
 
 use crate::codegen::{codegen, RustFile};
 use crate::eval::eval_context;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,144 @@
+use derive_new::new;
+use rustc_hash::FxHashMap;
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::hash::Hash;
+
+crate mod dyn_descriptor;
+crate mod storage;
+
+crate trait BaseQueryContext: Sized {
+    /// A "query descriptor" packages up all the possible queries and a key.
+    /// It is used to store information about (e.g.) the stack.
+    ///
+    /// At runtime, it can be implemented in various ways: a monster enum
+    /// works for a fixed set of queries, but a boxed trait object is good
+    /// for a more open-ended option.
+    type QueryDescriptor: Debug + Eq;
+
+    fn execute_query_implementation<Q>(
+        &self,
+        descriptor: Self::QueryDescriptor,
+        key: &Q::Key,
+    ) -> Q::Value
+    where
+        Q: Query<Self>;
+
+    /// Reports an unexpected cycle attempting to access the query Q with the given key.
+    fn report_unexpected_cycle(&self, descriptor: Self::QueryDescriptor) -> !;
+}
+
+crate trait Query<QC: BaseQueryContext>: Debug + Default + Sized + 'static {
+    type Key: Clone + Debug + Hash + Eq;
+    type Value: Clone + Debug + Hash + Eq;
+    type Storage: QueryStorageOps<QC, Self>;
+
+    fn execute(query: &QC, key: Self::Key) -> Self::Value;
+}
+
+crate trait QueryStorageOps<QC, Q>
+where
+    QC: BaseQueryContext,
+    Q: Query<QC>,
+{
+    fn try_fetch<'q>(
+        &self,
+        query: &'q QC,
+        key: &Q::Key,
+        descriptor: impl FnOnce() -> QC::QueryDescriptor,
+    ) -> Result<Q::Value, CycleDetected>;
+}
+
+#[derive(new)]
+crate struct QueryTable<'me, QC, Q>
+where
+    QC: BaseQueryContext,
+    Q: Query<QC>,
+{
+    crate query: &'me QC,
+    crate storage: &'me Q::Storage,
+    crate descriptor_fn: fn(&QC, &Q::Key) -> QC::QueryDescriptor,
+}
+
+#[derive(Debug)]
+crate enum QueryState<V> {
+    InProgress,
+    Memoized(V),
+}
+
+crate struct CycleDetected;
+
+impl<QC, Q> QueryTable<'me, QC, Q>
+where
+    QC: BaseQueryContext,
+    Q: Query<QC>,
+{
+    crate fn of(&self, key: Q::Key) -> Q::Value {
+        self.storage
+            .try_fetch(self.query, &key, || self.descriptor(&key))
+            .unwrap_or_else(|CycleDetected| {
+                self.query.report_unexpected_cycle(self.descriptor(&key))
+            })
+    }
+
+    fn descriptor(&self, key: &Q::Key) -> QC::QueryDescriptor {
+        (self.descriptor_fn)(self.query, key)
+    }
+}
+
+/// A macro helper for writing the query contexts in traits that helps
+/// you avoid repeating information.
+///
+/// Example:
+///
+/// ```
+/// trait TypeckQueryContext {
+///     query_prototype!(fn <method>() for <type>);
+/// }
+/// ```
+macro_rules! query_prototype {
+    (
+        $(#[$attr:meta])*
+        fn $method_name:ident() for $query_type:ty
+    ) => {
+        $(#[$attr])*
+        fn $method_name(&self) -> $crate::query::QueryTable<'_, Self, $query_type>;
+    }
+}
+
+/// Example:
+///
+/// ```
+/// query_definition! {
+///     QueryName(query: &impl TypeckQueryContext, key: DefId) -> Arc<Vec<DefId>> {
+///         ...       
+///     }
+/// }
+macro_rules! query_definition {
+    (
+        $(#[$attr:meta])*
+        $v:vis $name:ident($query:tt : &impl $query_trait:path, $key:tt : $key_ty:ty) -> $value_ty:ty {
+            $($body:tt)*
+        }
+    ) => {
+        #[derive(Default, Debug)]
+        $v struct $name;
+
+        impl<QC> $crate::query::Query<QC> for $name
+        where
+            QC: $query_trait,
+        {
+            type Key = $key_ty;
+            type Value = $value_ty;
+            type Storage = $crate::query::storage::MemoizedStorage<QC, Self>;
+
+            fn execute($query: &QC, $key: $key_ty) -> $value_ty {
+                $($body)*
+            }
+        }
+    }
+}

--- a/src/query/dyn_descriptor.rs
+++ b/src/query/dyn_descriptor.rs
@@ -1,0 +1,47 @@
+use crate::query::BaseQueryContext;
+use crate::query::Query;
+use crate::query::QueryTable;
+use crate::typeck::query::TypeckQueryContext;
+use rustc_hash::FxHashMap;
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::hash::Hash;
+
+// Total hack for now: assume that the Debug string
+// for the key, combined with the type-id of the query,
+// is sufficient for an equality comparison.
+
+/// A simple-to-use query descriptor that is meant only for dumping
+/// out cycle stack errors and not for any real recovery; also, not
+/// especially efficient.
+#[derive(PartialEq, Eq)]
+crate struct DynDescriptor {
+    type_id: TypeId,
+    debug_string: String,
+}
+
+impl DynDescriptor {
+    crate fn from_key<QC, Q>(_query: &QC, key: &Q::Key) -> DynDescriptor
+    where
+        QC: BaseQueryContext,
+        Q: Query<QC>,
+    {
+        let type_id = TypeId::of::<Q>();
+        let query = Q::default();
+        let debug_string = format!("Query `{:?}` applied to `{:?}`", query, key);
+        DynDescriptor {
+            type_id,
+            debug_string,
+        }
+    }
+}
+
+impl std::fmt::Debug for DynDescriptor {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.debug_string)
+    }
+}

--- a/src/query/storage.rs
+++ b/src/query/storage.rs
@@ -1,0 +1,74 @@
+use crate::query::BaseQueryContext;
+use crate::query::CycleDetected;
+use crate::query::Query;
+use crate::query::QueryState;
+use crate::query::QueryStorageOps;
+use crate::query::QueryTable;
+use rustc_hash::FxHashMap;
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::hash::Hash;
+
+// The master implementation that knits together all the queries
+// contains a certain amount of boilerplate. This file aims to
+// reduce that.
+
+crate struct MemoizedStorage<QC, Q>
+where
+    Q: Query<QC>,
+    QC: BaseQueryContext,
+{
+    map: RefCell<FxHashMap<Q::Key, QueryState<Q::Value>>>,
+}
+
+impl<QC, Q> QueryStorageOps<QC, Q> for MemoizedStorage<QC, Q>
+where
+    Q: Query<QC>,
+    QC: BaseQueryContext,
+{
+    fn try_fetch<'q>(
+        &self,
+        query: &'q QC,
+        key: &Q::Key,
+        descriptor: impl FnOnce() -> QC::QueryDescriptor,
+    ) -> Result<Q::Value, CycleDetected> {
+        {
+            let mut map = self.map.borrow_mut();
+            match map.entry(key.clone()) {
+                Entry::Occupied(entry) => {
+                    return match entry.get() {
+                        QueryState::InProgress => Err(CycleDetected),
+                        QueryState::Memoized(value) => Ok(value.clone()),
+                    };
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(QueryState::InProgress);
+                }
+            }
+        }
+
+        // If we get here, the query is in progress, and we are the
+        // ones tasked with finding its final value.
+        let descriptor = descriptor();
+        let value = query.execute_query_implementation::<Q>(descriptor, key);
+
+        {
+            let mut map = self.map.borrow_mut();
+            let old_value = map.insert(key.clone(), QueryState::Memoized(value.clone()));
+            assert!(
+                match old_value {
+                    Some(QueryState::InProgress) => true,
+                    _ => false,
+                },
+                "expected in-progress state, not {:?}",
+                old_value
+            );
+        }
+
+        Ok(value)
+    }
+}

--- a/src/query_impl.rs
+++ b/src/query_impl.rs
@@ -1,0 +1,75 @@
+use crate::query::dyn_descriptor::DynDescriptor;
+use crate::query::BaseQueryContext;
+use crate::query::Query;
+use crate::query::QueryTable;
+use crate::typeck::query::TypeckQueryContext;
+use rustc_hash::FxHashMap;
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Write;
+use std::hash::Hash;
+
+crate struct QueryContextImpl {
+    storage: QueryContextImplStorage,
+    execution_stack: RefCell<Vec<DynDescriptor>>,
+}
+
+#[allow(non_snake_case)]
+struct QueryContextImplStorage {
+    Fields: <crate::typeck::query::Fields as Query<QueryContextImpl>>::Storage,
+    Ty: <crate::typeck::query::Ty as Query<QueryContextImpl>>::Storage,
+}
+
+impl BaseQueryContext for QueryContextImpl {
+    type QueryDescriptor = DynDescriptor;
+
+    fn execute_query_implementation<Q>(
+        &self,
+        descriptor: Self::QueryDescriptor,
+        key: &Q::Key,
+    ) -> Q::Value
+    where
+        Q: Query<Self>,
+    {
+        self.execution_stack.borrow_mut().push(descriptor);
+        let value = Q::execute(self, key.clone());
+        self.execution_stack.borrow_mut().pop();
+        value
+    }
+
+    fn report_unexpected_cycle(&self, descriptor: Self::QueryDescriptor) -> ! {
+        let execution_stack = self.execution_stack.borrow();
+        let start_index = (0..execution_stack.len())
+            .rev()
+            .filter(|&i| execution_stack[i] == descriptor)
+            .next()
+            .unwrap();
+
+        let mut message = format!("Internal error, cycle detected:\n");
+        for descriptor in &execution_stack[start_index..] {
+            writeln!(message, "- {:?}\n", descriptor).unwrap();
+        }
+        panic!(message)
+    }
+}
+
+impl TypeckQueryContext for QueryContextImpl {
+    fn fields(&self) -> QueryTable<'_, Self, crate::typeck::query::Fields> {
+        QueryTable::new(
+            self,
+            &self.storage.Fields,
+            DynDescriptor::from_key::<Self, crate::typeck::query::Fields>,
+        )
+    }
+
+    fn ty(&self) -> QueryTable<'_, Self, crate::typeck::query::Ty> {
+        QueryTable::new(
+            self,
+            &self.storage.Ty,
+            DynDescriptor::from_key::<Self, crate::typeck::query::Ty>,
+        )
+    }
+}

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 
 mod infer;
 mod ops;
+crate mod query;
 
 struct TypeChecker {
     hir: Rc<hir::Hir>,

--- a/src/typeck/query.rs
+++ b/src/typeck/query.rs
@@ -1,0 +1,38 @@
+use crate::ir::DefId;
+use crate::query::Query;
+use std::sync::Arc;
+
+crate trait TypeckQueryContext: crate::query::BaseQueryContext {
+    query_prototype!(
+        /// Find the fields of a struct.
+        fn fields() for Fields
+    );
+
+    query_prototype!(
+        /// Find the type of something.
+        fn ty() for Ty
+    );
+}
+
+query_definition! {
+    /// Test documentation.
+    crate Fields(_: &impl TypeckQueryContext, _: DefId) -> Arc<Vec<DefId>> {
+        Arc::new(vec![])
+    }
+}
+
+#[derive(Default, Debug)]
+crate struct Ty;
+
+impl<QC> Query<QC> for Ty
+where
+    QC: TypeckQueryContext,
+{
+    type Key = DefId;
+    type Value = Arc<Vec<DefId>>;
+    type Storage = crate::query::storage::MemoizedStorage<QC, Self>;
+
+    fn execute(query: &QC, key: DefId) -> Arc<Vec<DefId>> {
+        query.ty().of(key)
+    }
+}


### PR DESCRIPTION
This is a "roughly complete" sketch for how the query system might work. It tries to hit a few goals:

- We don't have to have a base crate that declares the "complete set of queries"
- Each module only has to know about the queries that it depends on and that it provides (but no others)
- Compiles to fast code, with no allocation, dynamic dispatch, etc on the "memoized hit" fast path
- Can recover from cycles gracefully (though I didn't really show that)

The way that it is meant to be used is roughly like this:

### Invoking a query

You will always be threading around a "query" context value. To invoke a query `foo` on the value `key`, you do:

```rust
query.foo().of(key)
```

The syntax is intended to be extensible, so we can add other methods besides `of` eventually (e.g., you might want methods that potentially recover from a cycle, which `of` does not). We could change this to `query.foo(key)`, which is what rustc does, with minimal hassle.

### Defining query traits

Each "major module" X will declare a trait with the queries it provides. This trait should extend the traits for other modules that X relies on. There will eventually be a "central context" that implements all the traits for all the modules. 

So, for example, the typeck module here declares:

```rust
crate trait TypeckQueryContext: crate::query::BaseQueryContext {
    query_prototype!(
        /// Find the fields of a struct.
        fn fields() for Fields
    );

    query_prototype!(
        /// Find the type of something.
        fn ty() for Ty
    );
}
```

Here, the trait basically says: "the final context must be provide implementations of these two queries (`Fields` and `Ty`)". The macro specifies a method name which is expected to be the "camel case" version of the full query name (`fields`, `ty` respectively).

The `BaseQueryContext` trait is just the .. well .. basic query context operations. In general, I would expect to see some other modules instead, so something like:

```rust
crate trait TypeckQueryContext: HirQueryContext { .. }
```

where the `HirQueryContext` is a trait that defines the queries related to HIR construction.

Note that these traits are not limited to containing queries: we can basically add whatever methods we want that the "central context" must provide (e.g., I expect to add a global interner in there).

### Defining query implementations

In addition to defining the trait with the queries that it exports, the typeck module will also implement those queries. This is done most easily by using the `query_definition!` macro. Here is an example defining `Fields`:

```rust
query_definition! {
    /// Test documentation.
    crate Fields(_query: &impl TypeckQueryContext, _def_id: DefId) -> Arc<Vec<DefId>> {
        Arc::new(vec![])
    }
}
```

This is obviously a dummy implementation, but you get the idea.

### Defining query implementations the long-hand way

A query is really defined by a kind of "dummy" type that implements the `Query` trait. This is the sort of code that macro above generates:

```rust
#[derive(Default, Debug)]
crate struct Ty;

impl<QC> Query<QC> for Ty
where
    QC: TypeckQueryContext,
{
    type Key = DefId;
    type Value = Arc<Vec<DefId>>;
    type Storage = crate::query::storage::MemoizedStorage<QC, Self>;

    fn execute(query: &QC, key: DefId) -> Arc<Vec<DefId>> {
        query.ty().of(key)
    }
}
```

### Customizing query storage etc

Each query defines its storage. Right now I only sketched out one form of storage -- memoized storage -- but eventualy I would expect to permit a few options here. e.g., "immediate" queries, that just *always* execute on demand, as well as queries that interact with an incremental system.