### PR TITLE
Fix build error with recent Rust nightly

### DIFF
--- a/src/parser/ast/debug.rs
+++ b/src/parser/ast/debug.rs
@@ -5,7 +5,7 @@ use crate::parser::ModuleTable;
 
 use std::fmt;
 
-pub struct DebuggableVec<'owner, T: DebugModuleTable + 'owner> {
+pub struct DebuggableVec<'owner, T: DebugModuleTable> {
     inner: &'owner Vec<T>,
     table: &'owner ModuleTable,
 }
@@ -29,7 +29,7 @@ impl<T: DebugModuleTable> fmt::Debug for DebuggableVec<'table, T> {
     }
 }
 
-pub struct Debuggable<'owner, T: DebugModuleTable + 'owner> {
+pub struct Debuggable<'owner, T: DebugModuleTable> {
     inner: &'owner T,
     table: &'owner ModuleTable,
 }


### PR DESCRIPTION
This removes unneeded lifetime bounds on the recommendation of the recent Rust compiler update.