### PR TITLE
Add support for completions. Clean up package.jsons

### DIFF
--- a/lark/client/package-lock.json
+++ b/lark/client/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "lsp-sample-client",
+	"name": "lark",
 	"version": "0.0.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/lark/client/package.json
+++ b/lark/client/package.json
@@ -2,13 +2,13 @@
 	"name": "lark",
 	"displayName": "lark",
 	"description": "Lark IDE support",
-	"author": "Microsoft Corporation",
+	"author": "Lark developers",
 	"license": "MIT",
 	"version": "0.0.1",
 	"publisher": "vscode",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-extension-samples"
+		"url": "https://github.com/lark-exploration/lark"
 	},
 	"engines": {
 		"vscode": "^1.23.0"

--- a/lark/package-lock.json
+++ b/lark/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "lsp-lark",
+	"name": "lark",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/lark/package.json
+++ b/lark/package.json
@@ -6,7 +6,7 @@
 	"version": "1.0.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-extension-samples"
+		"url": "https://github.com/lark-exploration/lark"
 	},
 	"publisher": "vscode",
 	"categories": [],


### PR DESCRIPTION
Adds support for completions in the LSP implementation. The currently returns some example data.

Also fixes some leftover copy pasta in the package.json files.