### PR TITLE
Begin workspace refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "codegen"
+version = "0.1.0"
+dependencies = [
+ "ir 0.1.0",
+]
+
+[[package]]
 name = "codespan"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +134,13 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "eval"
+version = "0.1.0"
+dependencies = [
+ "ir 0.1.0",
 ]
 
 [[package]]
@@ -188,6 +202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ide"
+version = "0.1.0"
+dependencies = [
+ "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "task_manager 0.1.0",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +226,10 @@ dependencies = [
 name = "indexmap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ir"
+version = "0.1.0"
 
 [[package]]
 name = "itertools"
@@ -260,12 +289,16 @@ dependencies = [
 name = "lark"
 version = "0.1.0"
 dependencies = [
+ "codegen 0.1.0",
  "codespan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eval 0.1.0",
  "generational-arena 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ide 0.1.0",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ir 0.1.0",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-reporting 0.1.3 (git+https://github.com/wycats/language-reporting.git)",
@@ -277,10 +310,8 @@ dependencies = [
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "smart-default 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "task_manager 0.1.0",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "text-diff 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -632,6 +663,14 @@ dependencies = [
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "task_manager"
+version = "0.1.0"
+dependencies = [
+ "ir 0.1.0",
+ "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ authors = [
 ]
 edition = '2018'
 
+[workspace]
+members = [
+    "components/ide",
+]
+
 [dependencies]
 codespan = "0.1.3"
 codespan-reporting = "0.1.4"
@@ -28,9 +33,12 @@ itertools = "0.7.8"
 text-diff = "0.4.0"
 languageserver-types = "0.51.0"
 salsa = "0.4.1"
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+
+codegen = { path = "components/codegen" }
+eval = { path = "components/eval" }
+ide = { path = "components/ide" }
+ir = { path = "components/ir" }
+task_manager = { path = "components/task_manager" }
 
 [dev-dependencies]
 unindent = "0.1.3"

--- a/components/codegen/Cargo.toml
+++ b/components/codegen/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "codegen"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ir = { path = "../ir" }

--- a/components/codegen/src/lib.rs
+++ b/components/codegen/src/lib.rs
@@ -1,6 +1,6 @@
-use crate::ir::{
-    builtin_type, BasicBlock, BinOp, BuiltinFn, Context, DefId, Definition, Function, Operand,
-    Place, Rvalue, Statement, StatementKind, Struct, Terminator, TerminatorKind, Ty, VarId,
+use ir::{
+    builtin_type, BasicBlock, BinOp, BuiltinFn, Context, Definition, Function, Operand, Place,
+    Rvalue, StatementKind, Struct, Terminator, TerminatorKind, Ty, VarId,
 };
 
 pub struct RustFile {

--- a/components/eval/Cargo.toml
+++ b/components/eval/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "eval"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ir = { path = "../ir" }

--- a/components/eval/src/lib.rs
+++ b/components/eval/src/lib.rs
@@ -1,6 +1,6 @@
-use crate::ir::{
-    builtin_type, BinOp, BuiltinFn, Context, DefId, Definition, Function, Operand, Place, Rvalue,
-    Statement, StatementKind,
+use ir::{
+    BinOp, BuiltinFn, Context, DefId, Definition, Function, Operand, Place, Rvalue, Statement,
+    StatementKind,
 };
 use std::collections::HashMap;
 use std::fmt;

--- a/components/ide/Cargo.toml
+++ b/components/ide/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ide"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+serde_json = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
+languageserver-types = "0.51.0"
+
+task_manager = { path = "../task_manager" }

--- a/components/ide/src/lib.rs
+++ b/components/ide/src/lib.rs
@@ -1,11 +1,9 @@
-use crate::task_manager::{self, Actor, LspRequest, LspResponse, MsgToManager};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_derive::{Deserialize, Serialize};
 use std::io;
 use std::io::prelude::{Read, Write};
 use std::sync::mpsc::Sender;
-
-pub use languageserver_types::Position;
+use task_manager::{self, Actor, LspRequest, LspResponse, MsgToManager};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "method")]

--- a/components/ir/Cargo.toml
+++ b/components/ir/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ir"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/components/ir/src/lib.rs
+++ b/components/ir/src/lib.rs
@@ -26,7 +26,7 @@ pub struct Function {
 }
 
 impl Function {
-    crate fn new(return_ty: Ty, mut args: Vec<LocalDecl>, name: String) -> Function {
+    pub fn new(return_ty: Ty, mut args: Vec<LocalDecl>, name: String) -> Function {
         let arg_count = args.len();
         let mut local_decls = vec![LocalDecl::new_return_place(return_ty)];
         local_decls.append(&mut args);
@@ -39,7 +39,7 @@ impl Function {
         }
     }
 
-    crate fn new_temp(&mut self, ty: Ty) -> VarId {
+    pub fn new_temp(&mut self, ty: Ty) -> VarId {
         self.local_decls.push(LocalDecl::new_temp(ty));
         self.local_decls.len() - 1
     }
@@ -56,7 +56,7 @@ pub struct Struct {
 }
 
 impl Struct {
-    crate fn field(mut self, name: String, ty: Ty) -> Self {
+    pub fn field(mut self, name: String, ty: Ty) -> Self {
         self.fields.push(Field { ty, name });
         self
     }
@@ -71,7 +71,7 @@ impl Struct {
 
 #[derive(Debug)]
 pub struct Field {
-    crate ty: Ty,
+    pub ty: Ty,
     pub name: String,
 }
 
@@ -160,23 +160,23 @@ pub enum BinOp {
 
 #[derive(Debug)]
 pub struct LocalDecl {
-    crate ty: Ty,
+    pub ty: Ty,
     pub name: Option<String>,
 }
 
 impl LocalDecl {
-    crate fn new_return_place(return_ty: Ty) -> LocalDecl {
+    pub fn new_return_place(return_ty: Ty) -> LocalDecl {
         LocalDecl {
             ty: return_ty,
             name: None,
         }
     }
 
-    crate fn new_temp(ty: Ty) -> LocalDecl {
+    pub fn new_temp(ty: Ty) -> LocalDecl {
         LocalDecl { ty, name: None }
     }
 
-    crate fn new(ty: Ty, name: Option<String>) -> LocalDecl {
+    pub fn new(ty: Ty, name: Option<String>) -> LocalDecl {
         LocalDecl { ty, name }
     }
 }
@@ -225,147 +225,11 @@ impl Context {
         self.definitions.len() - 1
     }
 
-    crate fn simple_type_for_def_id(&self, def_id: DefId) -> Ty {
+    pub fn simple_type_for_def_id(&self, def_id: DefId) -> Ty {
         Ty { def_id: def_id }
     }
 
-    crate fn get_def_id_for_ty(&self, ty: Ty) -> Option<DefId> {
+    pub fn get_def_id_for_ty(&self, ty: Ty) -> Option<DefId> {
         Some(ty.def_id)
     }
 }
-
-/*
-use crate::indices::{Index, IndexVec};
-
-pub type DefId = usize;
-pub type VarId = usize;
-
-struct BasicBlock;
-
-#[derive(Debug)]
-pub struct Variable {
-    pub ty: DefId,
-    pub name: String,
-}
-
-#[derive(Debug)]
-pub struct Param {
-    pub ty: DefId,
-    pub name: String,
-    pub var_id: VarId,
-}
-
-#[derive(Debug)]
-pub struct Struct {
-    pub fields: Vec<Variable>,
-    pub name: String,
-}
-
-impl Struct {
-    pub fn field(mut self, name: String, ty: DefId) -> Self {
-        self.fields.push(Variable { ty, name });
-        self
-    }
-
-    pub fn new(name: String) -> Self {
-        Struct {
-            name,
-            fields: vec![],
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Function {
-    pub params: Vec<Param>,
-    pub body: Vec<Command>,
-    pub ret_ty: DefId,
-    pub name: String,
-    pub vars: Vec<Variable>,
-}
-
-impl Function {
-    pub fn param(mut self, name: String, ty: DefId) -> Self {
-        self.vars.push(Variable {
-            ty,
-            name: name.clone(),
-        });
-        let var_id = self.vars.len() - 1;
-        self.params.push(Param { ty, name, var_id });
-        self
-    }
-
-    pub fn new(name: String, ret_ty: DefId) -> Function {
-        Function {
-            params: vec![],
-            body: vec![],
-            ret_ty,
-            name,
-            vars: vec![],
-        }
-    }
-}
-
-pub mod builtin_type {
-    #[allow(unused)]
-    pub const UNKNOWN: usize = 0;
-    pub const VOID: usize = 1;
-    pub const I32: usize = 2;
-    pub const STRING: usize = 3;
-    pub const ERROR: usize = 100;
-}
-
-#[derive(Debug)]
-pub enum BuiltinFn {
-    StringInterpolate,
-}
-
-#[derive(Debug)]
-pub enum Definition {
-    Builtin,
-    BuiltinFn(BuiltinFn),
-    Fn(Function),
-    Struct(Struct),
-    Borrow(DefId),
-    #[allow(unused)]
-    Move(DefId),
-}
-
-#[derive(Debug)]
-pub enum Command {
-    VarUse(VarId),
-    VarDeclWithInit(VarId),
-    ConstInt(i32),
-    ConstString(String),
-    Call(DefId),
-    #[allow(unused)]
-    Add,
-    Sub,
-    Dot(String),
-    ReturnLastStackValue,
-    DebugPrint,
-}
-
-pub struct Context {
-    pub definitions: Vec<Definition>,
-}
-
-impl Context {
-    pub fn new() -> Context {
-        let mut definitions = vec![];
-
-        for _ in 0..(builtin_type::ERROR + 1) {
-            definitions.push(Definition::Builtin); // UNKNOWN
-        }
-
-        definitions.push(Definition::BuiltinFn(BuiltinFn::StringInterpolate));
-
-        Context { definitions }
-    }
-
-    pub fn add_definition(&mut self, def: Definition) -> usize {
-        self.definitions.push(def);
-        self.definitions.len() - 1
-    }
-}
-*/

--- a/components/task_manager/Cargo.toml
+++ b/components/task_manager/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "task_manager"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+languageserver-types = "0.51.0"
+ir = { path = "../ir" }

--- a/components/task_manager/src/lib.rs
+++ b/components/task_manager/src/lib.rs
@@ -1,9 +1,10 @@
+use languageserver_types::Position;
+
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::thread::{self, JoinHandle};
+use std::thread;
 
-use crate::ide::{LspResponder, Position};
-use crate::ir::DefId;
+use ir::DefId;
 
 type TaskId = usize;
 

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -1,11 +1,11 @@
 //! The `Hir` is the "high-level IR". It is a simpified, somewhat resolved version of the bare AST.
 
 use crate::indices::{IndexVec, U32Index};
-use crate::ir::DefId;
 use crate::parser::pos::{Span, Spanned};
 use crate::parser::StringId;
 use crate::ty;
 use crate::ty::declaration::Declaration;
+use ir::DefId;
 use std::sync::Arc;
 
 crate mod query_definitions;

--- a/src/hir/query_definitions.rs
+++ b/src/hir/query_definitions.rs
@@ -1,9 +1,9 @@
 use crate::hir;
 use crate::hir::HirDatabase;
-use crate::ir::DefId;
 use crate::parser::StringId;
 use crate::ty;
 use crate::ty::declaration::Declaration;
+use ir::DefId;
 use std::sync::Arc;
 
 crate fn boolean_def_id(_db: &impl HirDatabase, _key: ()) -> DefId {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,17 +22,12 @@ mod lexer;
 #[macro_use]
 mod indices;
 
-mod codegen;
 mod debug;
-mod eval;
 mod hir;
-mod ide;
 mod intern;
-mod ir;
 mod map;
 mod parser;
 mod parser2;
-mod task_manager;
 mod tests;
 mod ty;
 mod type_check;
@@ -40,8 +35,8 @@ mod unify;
 
 use std::{env, io};
 
-use crate::ide::{lsp_serve, LspResponder};
-use crate::task_manager::{Actor, FakeTypeChecker};
+use ide::{lsp_serve, LspResponder};
+use task_manager::{Actor, FakeTypeChecker};
 
 fn build(_filename: &str) {}
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
-use crate::codegen::{codegen, RustFile};
-use crate::eval::eval_context;
-use crate::ir::{
+use codegen::{codegen, RustFile};
+use eval::eval_context;
+use ir::{
     builtin_type, BasicBlock, BinOp, Context, Definition, Function, LocalDecl, Operand, Place,
     Rvalue, StatementKind, Struct, TerminatorKind,
 };

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -1,10 +1,10 @@
 #![warn(unused_imports)]
 
 use crate::indices::IndexVec;
-use crate::ir::DefId;
 use crate::parser::program::StringId;
 use crate::ty::interners::HasTyInternTables;
 use crate::unify::InferVar;
+use ir::DefId;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::IntoIterator;

--- a/src/ty/map_family.rs
+++ b/src/ty/map_family.rs
@@ -1,6 +1,6 @@
-use crate::ir::DefId;
 use crate::ty::interners::HasTyInternTables;
 use crate::ty::{self, TypeFamily};
+use ir::DefId;
 use std::sync::Arc;
 
 crate trait Map<S: TypeFamily, T: TypeFamily>: Clone {

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -3,7 +3,6 @@
 use codespan_reporting::Diagnostic;
 use crate::hir;
 use crate::indices::IndexVec;
-use crate::ir::DefId;
 use crate::map::FxIndexMap;
 use crate::parser::Span;
 use crate::ty;
@@ -22,6 +21,7 @@ use crate::unify::InferVar;
 use crate::unify::Inferable;
 use crate::unify::UnificationTable;
 use generational_arena::Arena;
+use ir::DefId;
 use std::sync::Arc;
 
 mod base_only;

--- a/src/type_check/base_only.rs
+++ b/src/type_check/base_only.rs
@@ -1,6 +1,5 @@
 use crate::hir;
 use crate::hir::HirDatabase;
-use crate::ir::DefId;
 use crate::ty;
 use crate::ty::base_only::{Base, BaseOnly, BaseTy};
 use crate::ty::declaration::Declaration;
@@ -21,6 +20,7 @@ use crate::type_check::TypeCheckFamily;
 use crate::type_check::TypeChecker;
 use crate::type_check::TypeCheckerFields;
 use crate::unify::{InferVar, UnificationTable};
+use ir::DefId;
 use std::sync::Arc;
 
 impl TypeCheckFamily for BaseOnly {

--- a/src/type_check/hir_typeck.rs
+++ b/src/type_check/hir_typeck.rs
@@ -1,6 +1,5 @@
 use crate::hir;
 use crate::hir::HirDatabase;
-use crate::ir::DefId;
 use crate::ty;
 use crate::ty::base_only::{Base, BaseOnly, BaseTy};
 use crate::ty::declaration::Declaration;
@@ -20,6 +19,7 @@ use crate::type_check::TypeCheckFamily;
 use crate::type_check::TypeChecker;
 use crate::type_check::TypeCheckerFields;
 use crate::unify::{InferVar, UnificationTable};
+use ir::DefId;
 use std::sync::Arc;
 
 impl<DB, F> TypeChecker<'_, DB, F>

--- a/src/type_check/ops.rs
+++ b/src/type_check/ops.rs
@@ -1,5 +1,4 @@
 use crate::hir;
-use crate::ir::DefId;
 use crate::ty;
 use crate::ty::declaration::Declaration;
 use crate::ty::interners::TyInternTables;
@@ -19,6 +18,7 @@ use crate::type_check::UniverseBinder;
 use crate::unify::InferVar;
 use crate::unify::Inferable;
 use generational_arena::Arena;
+use ir::DefId;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct OpIndex {

--- a/src/type_check/query_definitions.rs
+++ b/src/type_check/query_definitions.rs
@@ -2,7 +2,6 @@ use codespan_reporting::Diagnostic;
 use crate::hir;
 use crate::hir::HirDatabase;
 use crate::indices::IndexVec;
-use crate::ir::DefId;
 use crate::map::FxIndexMap;
 use crate::parser::Span;
 use crate::ty;
@@ -19,6 +18,7 @@ use crate::type_check::UniverseBinder;
 use crate::unify::InferVar;
 use crate::unify::UnificationTable;
 use generational_arena::Arena;
+use ir::DefId;
 use std::sync::Arc;
 
 crate fn base_type_check(


### PR DESCRIPTION
This begins refactoring the project into separate crates in a workspace. Each of these subproject crates now lives in a "components" directory.

So far, the following crates have been moved:
* codegen
* eval
* ide
* ir
* task_manager
