### PR TITLE
Add cancellation action to task manager

### DIFF
--- a/components/ide/src/lib.rs
+++ b/components/ide/src/lib.rs
@@ -203,9 +203,18 @@ pub fn lsp_serve(send_to_manager_channel: Sender<task_manager::MsgToManager>) {
                             //for more expensive computations on a completion (like fetching the docs)
                             eprintln!("resolve completion item: id={} {:#?}", id, params);
                         }
-                        Ok(LSPCommand::cancelRequest { params }) => {
-                            eprintln!("cancel request: {:#?}", params);
-                        }
+                        Ok(LSPCommand::cancelRequest {
+                            params: languageserver_types::CancelParams { id },
+                        }) => match id {
+                            languageserver_types::NumberOrString::Number(num) => {
+                                eprintln!("cancelling item: id={}", num);
+                                let _ = send_to_manager_channel
+                                    .send(MsgToManager::Cancel(num as usize));
+                            }
+                            _ => unimplemented!(
+                                "Non-number cancellation IDs not currently supported"
+                            ),
+                        },
                         Err(e) => eprintln!("Error handling command: {:?}", e),
                     }
                 }

--- a/components/task_manager/src/lib.rs
+++ b/components/task_manager/src/lib.rs
@@ -41,6 +41,7 @@ pub enum LspResponse {
 pub enum MsgToManager {
     TypeResponse(TypeResponse),
     LspRequest(LspRequest),
+    Cancel(TaskId),
     Shutdown,
 }
 
@@ -294,6 +295,10 @@ impl TaskManager {
                 }
                 Ok(MsgToManager::LspRequest(lsp_request)) => {
                     self.do_recipe_for_lsp_request(lsp_request);
+                }
+                Ok(MsgToManager::Cancel(task_id)) => {
+                    //Note: In the future we may have multiple steps to cancel a task
+                    self.live_recipes.remove(&task_id);
                 }
                 Ok(MsgToManager::Shutdown) => {
                     let _ = self.lsp_responder.channel.send(MsgFromManager::Shutdown);


### PR DESCRIPTION
This adds a simple cancellation step to the task manager. Right now, it just removes the task. We can extend this to do more in the future.