### PR TITLE
refactorings towards merging parser etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-reporting 0.1.3 (git+https://github.com/wycats/language-reporting.git)",
  "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lark-string 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "map 0.1.0",
@@ -361,6 +362,16 @@ dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unify 0.1.0",
  "unindent 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lark-string"
+version = "0.1.0"
+dependencies = [
+ "debug 0.1.0",
+ "indices 0.1.0",
+ "intern 0.1.0",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ version = "0.1.0"
 dependencies = [
  "indices 0.1.0",
  "map 0.1.0",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "debug 0.1.0",
  "indices 0.1.0",
  "intern 0.1.0",
+ "lark-debug-derive 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
  "salsa 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -342,6 +343,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-reporting 0.1.3 (git+https://github.com/wycats/language-reporting.git)",
  "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lark-debug-derive 0.1.0",
  "lark-string 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -362,6 +364,15 @@ dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unify 0.1.0",
  "unindent 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lark-debug-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ salsa = "0.5.0"
 
 codegen = { path = "components/codegen" }
 debug = { path = "components/debug" }
+lark-debug-derive = { path = "components/lark-debug-derive" }
 eval = { path = "components/eval" }
 ide = { path = "components/ide" }
 indices = { path = "components/indices" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ ide = { path = "components/ide" }
 indices = { path = "components/indices" }
 intern = { path = "components/intern" }
 hir = { path = "components/hir" }
+lark-string = { path = "components/lark-string" } 
 mir = { path = "components/mir" }
 map = { path = "components/map" }
 parser = { path = "components/parser" }

--- a/components/ast/Cargo.toml
+++ b/components/ast/Cargo.toml
@@ -9,6 +9,7 @@ parking_lot = "0.6.4"
 salsa = "0.5.0"
 
 debug = { path = "../debug" }
+lark-debug-derive = { path = "../lark-debug-derive" }
 indices = { path = "../indices" }
 intern = { path = "../intern" }
 parser = { path = "../parser" }

--- a/components/ast/src/item_id.rs
+++ b/components/ast/src/item_id.rs
@@ -2,13 +2,14 @@ use crate::HasParserState;
 use debug::DebugWith;
 use intern::Has;
 use intern::Untern;
+use lark_debug_derive::DebugWith;
 use parser::StringId;
 
 indices::index_type! {
     pub struct ItemId { .. }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, DebugWith, PartialEq, Eq, Hash)]
 pub enum ItemIdData {
     InputFile { file: StringId },
     ItemName { base: ItemId, id: StringId },
@@ -30,30 +31,6 @@ where
     fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let data = self.untern(cx);
         data.fmt_with(cx, fmt)
-    }
-}
-
-impl<Cx> DebugWith<Cx> for ItemIdData
-where
-    Cx: Has<ItemIdTables> + HasParserState,
-{
-    fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ItemIdData::InputFile { file } => fmt
-                .debug_struct("InputFile")
-                .field("file", &file.debug_with(cx))
-                .finish(),
-            ItemIdData::ItemName { base, id } => fmt
-                .debug_struct("ItemName")
-                .field("base", &base.debug_with(cx))
-                .field("id", &id.debug_with(cx))
-                .finish(),
-            ItemIdData::MemberName { base, id } => fmt
-                .debug_struct("MemberName")
-                .field("base", &base.debug_with(cx))
-                .field("id", &id.debug_with(cx))
-                .finish(),
-        }
     }
 }
 

--- a/components/ast/src/item_id.rs
+++ b/components/ast/src/item_id.rs
@@ -9,6 +9,8 @@ indices::index_type! {
     pub struct ItemId { .. }
 }
 
+debug::debug_fallback_impl!(ItemId);
+
 #[derive(Copy, Clone, Debug, DebugWith, PartialEq, Eq, Hash)]
 pub enum ItemIdData {
     InputFile { file: StringId },

--- a/components/ast/src/lib.rs
+++ b/components/ast/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_fn)]
 #![feature(const_let)]
 #![feature(macro_at_most_once_rep)]
+#![feature(specialization)]
 
 use crate::item_id::ItemId;
 use crate::item_id::ItemIdTables;

--- a/components/debug/src/lib.rs
+++ b/components/debug/src/lib.rs
@@ -8,9 +8,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(specialization)]
 
-use std::fmt::Debug;
-
-pub trait DebugWith<Cx: ?Sized>: Debug {
+pub trait DebugWith<Cx: ?Sized> {
     fn debug_with(&'me self, cx: &'me Cx) -> DebugCxPair<'me, Self, Cx> {
         DebugCxPair { value: self, cx }
     }
@@ -88,11 +86,38 @@ impl<Cx: ?Sized> DebugWith<Cx> for ! {
     }
 }
 
-impl<T, Cx: ?Sized> DebugWith<Cx> for T
-where
-    T: Debug,
-{
-    default fn fmt_with(&self, _cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self, fmt)
-    }
+/// Generates a `DebugWith` impl that accepts any `Cx` and uses the
+/// built-in `Debug` trait.
+#[macro_export]
+macro_rules! debug_fallback_impl {
+    ($($t:ty),* $(,)*) => {
+        $(
+            impl<Cx: ?Sized> DebugWith<Cx> for $t {
+                default fn fmt_with(
+                    &self,
+                    _cx: &Cx,
+                    fmt: &mut std::fmt::Formatter<'_>,
+                ) -> std::fmt::Result {
+                    std::fmt::Debug::fmt(self, fmt)
+                }
+            }
+        )*
+    };
+}
+
+debug_fallback_impl! {
+    i8,
+    i16,
+    i32,
+    i64,
+    isize,
+    u8,
+    u16,
+    u32,
+    u64,
+    usize,
+    char,
+    bool,
+    String,
+    str,
 }

--- a/components/debug/src/lib.rs
+++ b/components/debug/src/lib.rs
@@ -6,8 +6,11 @@
 #![feature(box_patterns)]
 #![feature(never_type)]
 #![feature(in_band_lifetimes)]
+#![feature(specialization)]
 
-pub trait DebugWith<Cx: ?Sized> {
+use std::fmt::Debug;
+
+pub trait DebugWith<Cx: ?Sized>: Debug {
     fn debug_with(&'me self, cx: &'me Cx) -> DebugCxPair<'me, Self, Cx> {
         DebugCxPair { value: self, cx }
     }
@@ -52,8 +55,44 @@ where
     }
 }
 
+impl<T, Cx: ?Sized> DebugWith<Cx> for std::sync::Arc<T>
+where
+    T: DebugWith<Cx>,
+{
+    fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        T::fmt_with(self, cx, fmt)
+    }
+}
+
+impl<T, Cx: ?Sized> DebugWith<Cx> for Box<T>
+where
+    T: DebugWith<Cx>,
+{
+    fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        T::fmt_with(self, cx, fmt)
+    }
+}
+
+impl<T, Cx: ?Sized> DebugWith<Cx> for std::rc::Rc<T>
+where
+    T: DebugWith<Cx>,
+{
+    fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        T::fmt_with(self, cx, fmt)
+    }
+}
+
 impl<Cx: ?Sized> DebugWith<Cx> for ! {
     fn fmt_with(&self, _cx: &Cx, _fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unreachable!()
+    }
+}
+
+impl<T, Cx: ?Sized> DebugWith<Cx> for T
+where
+    T: Debug,
+{
+    default fn fmt_with(&self, _cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, fmt)
     }
 }

--- a/components/intern/Cargo.toml
+++ b/components/intern/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 indices = { path = "../indices" }
 map = { path = "../map" }
+parking_lot = "0.6.4"

--- a/components/lark-debug-derive/Cargo.toml
+++ b/components/lark-debug-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lark-debug-derive"
+version = "0.1.0"
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "0.4"
+quote = "0.6"
+syn = "0.15"

--- a/components/lark-debug-derive/src/lib.rs
+++ b/components/lark-debug-derive/src/lib.rs
@@ -1,0 +1,159 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+
+#[macro_use]
+extern crate quote;
+
+use proc_macro2::TokenStream;
+
+#[proc_macro_derive(DebugWith)]
+pub fn derive_debug_with(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    // Parse the input tokens into a syntax tree.
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    // Used in the quasi-quotation below as `#name`.
+    let name = &input.ident;
+
+    // Generate an expression to sum up the heap size of each field.
+    let debug_with = debug_with(&input);
+
+    // Add a bound `T: HeapSize` to every type parameter T.
+    let generics = add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let syn::Generics {
+        lt_token: _,
+        params: impl_params,
+        gt_token: _,
+        where_clause: _,
+    } = syn::parse_quote! { #impl_generics };
+
+    let expanded = quote! {
+        // The generated impl.
+        impl < #(#impl_params,)* Cx > ::debug::DebugWith<Cx> for #name #ty_generics #where_clause {
+            fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                #debug_with
+            }
+        }
+    };
+
+    // Hand the output tokens back to the compiler.
+    proc_macro::TokenStream::from(expanded)
+}
+
+// Add a bound `T: HeapSize` to every type parameter T.
+fn add_trait_bounds(mut generics: syn::Generics) -> syn::Generics {
+    // For each existing parameter, add `T: DebugWith`
+    for param in &mut generics.params {
+        if let syn::GenericParam::Type(ref mut type_param) = *param {
+            type_param
+                .bounds
+                .push(syn::parse_quote!(::debug::DebugWith));
+        }
+    }
+
+    generics
+}
+
+// Generate an expression to sum up the heap size of each field.
+fn debug_with(input: &syn::DeriveInput) -> TokenStream {
+    match &input.data {
+        syn::Data::Struct(data) => debug_with_struct(&input.ident, data),
+        syn::Data::Enum(data) => debug_with_variants(&input.ident, data),
+        syn::Data::Union(_) => unimplemented!(),
+    }
+}
+
+fn debug_with_variants(type_name: &syn::Ident, data: &syn::DataEnum) -> TokenStream {
+    let variant_streams: Vec<_> = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_name = &variant.ident;
+            match &variant.fields {
+                syn::Fields::Named(fields) => {
+                    let fnames: &Vec<_> = &fields.named.iter().map(|f| &f.ident).collect();
+                    let fnames1: &Vec<_> = fnames;
+                    quote! {
+                        #type_name :: #variant_name { #(#fnames),* } => {
+                            fmt.debug_struct(stringify!(#variant_name))
+                                #(
+                                    .field(stringify!(#fnames), &#fnames1.debug_with(cx))
+                                )*
+                            .finish()
+                        }
+                    }
+                }
+
+                syn::Fields::Unnamed(fields) => {
+                    let all_names = vec!["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+                    if fields.unnamed.len() > all_names.len() {
+                        unimplemented!("too many variants")
+                    }
+                    let names = &all_names[0..fields.unnamed.len()];
+                    quote! {
+                        #type_name :: #variant_name { #(#names),* } => {
+                            fmt.debug_tuple(stringify!(#variant_name))
+                                #(
+                                    .field(&#names.debug_with(cx))
+                                )*
+                            .finish()
+                        }
+                    }
+                }
+
+                syn::Fields::Unit => {
+                    quote! {
+                        #type_name :: #variant_name => {
+                            fmt.debug_struct(stringify!(#variant_name)).finish()
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        match self {
+            #(#variant_streams)*
+        }
+    }
+}
+
+fn debug_with_struct(type_name: &syn::Ident, data: &syn::DataStruct) -> TokenStream {
+    match &data.fields {
+        syn::Fields::Named(fields) => {
+            // Expands to an expression like
+            //
+            //     fmt.debug_struct("foo").field("a", self.a.debug_with(cx)).finish()
+            let fnames: &Vec<_> = &fields.named.iter().map(|f| &f.ident).collect();
+            let fnames1 = fnames;
+            quote! {
+                fmt.debug_struct(stringify!(#type_name))
+                #(
+                    .field(stringify!(#fnames), &self.#fnames1.debug_with(cx))
+                )*
+                .finish()
+            }
+        }
+        syn::Fields::Unnamed(fields) => {
+            // Expands to an expression like
+            //
+            //     fmt.debug_tuple("foo").field(self.0.debug_with(cx)).finish()
+            let indices = 0..fields.unnamed.len();
+            quote! {
+                fmt.debug_tuple(stringify!(#type_name))
+                #(
+                    .field(&self.#indices.debug_with(cx))
+                )*
+                .finish()
+            }
+        }
+        syn::Fields::Unit => {
+            quote! {
+                fmt.debug_struct(stringify!(#type_name))
+                .finish()
+            }
+        }
+    }
+}

--- a/components/lark-string/Cargo.toml
+++ b/components/lark-string/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lark-string"
+version = "0.1.0"
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+edition = "2018"
+
+[dependencies]
+debug = { path = "../debug" }
+intern = { path = "../intern" }
+indices = { path = "../indices" }
+parking_lot = "0.6.4"

--- a/components/lark-string/src/lib.rs
+++ b/components/lark-string/src/lib.rs
@@ -15,6 +15,8 @@ indices::index_type! {
     pub struct StringId { .. }
 }
 
+debug::debug_fallback_impl!(StringId);
+
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StringData {
     data: Arc<String>,

--- a/components/lark-string/src/lib.rs
+++ b/components/lark-string/src/lib.rs
@@ -1,0 +1,86 @@
+//! String interning
+
+#![feature(macro_at_most_once_rep)]
+#![feature(const_fn)]
+#![feature(const_let)]
+
+use debug::DebugWith;
+use intern::Has;
+use intern::Intern;
+use intern::Untern;
+use std::sync::Arc;
+
+indices::index_type! {
+    pub struct StringId { .. }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StringData {
+    data: Arc<String>,
+}
+
+impl std::ops::Deref for StringData {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.data
+    }
+}
+
+impl AsRef<str> for StringData {
+    fn as_ref(&self) -> &str {
+        &self.data
+    }
+}
+
+impl std::borrow::Borrow<str> for StringData {
+    fn borrow(&self) -> &str {
+        &self.data
+    }
+}
+
+intern::intern_tables! {
+    pub struct StringTables {
+        struct StringTablesData {
+            strings: map(StringId, StringData),
+        }
+    }
+}
+
+impl Intern<StringTables> for &str {
+    type Key = StringId;
+
+    fn intern(self, interner: &dyn Has<StringTables>) -> Self::Key {
+        intern::intern_impl(
+            self,
+            interner,
+            |d| &d[..],
+            |d| StringData {
+                data: Arc::new(d.to_string()),
+            },
+        )
+    }
+}
+
+impl Intern<StringTables> for String {
+    type Key = StringId;
+
+    fn intern(self, interner: &dyn Has<StringTables>) -> Self::Key {
+        intern::intern_impl(
+            self,
+            interner,
+            |d| &d[..],
+            |d| StringData { data: Arc::new(d) },
+        )
+    }
+}
+
+impl<Cx> DebugWith<Cx> for StringId
+where
+    Cx: Has<StringTables>,
+{
+    fn fmt_with(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data = self.untern(cx);
+        write!(fmt, "{:?}", &data[..])
+    }
+}

--- a/components/lark-string/src/lib.rs
+++ b/components/lark-string/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(macro_at_most_once_rep)]
 #![feature(const_fn)]
 #![feature(const_let)]
+#![feature(specialization)]
 
 use debug::DebugWith;
 use intern::Has;

--- a/components/lark-string/src/main.rs
+++ b/components/lark-string/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/components/map/src/lib.rs
+++ b/components/map/src/lib.rs
@@ -5,3 +5,4 @@ use std::hash::BuildHasherDefault;
 
 pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 pub type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
+pub use indexmap::Equivalent;

--- a/components/parser/src/lib.rs
+++ b/components/parser/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(box_patterns)]
 #![feature(nll)]
 #![feature(in_band_lifetimes)]
+#![feature(specialization)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/components/parser/src/parser/program.rs
+++ b/components/parser/src/parser/program.rs
@@ -42,7 +42,7 @@ pub struct Strings {
 
     #[new(default)]
     #[default = "vec![]"]
-    to_string: Vec<Spanned<String>>,
+    to_string: Vec<String>,
 }
 
 impl Strings {
@@ -59,7 +59,7 @@ impl Strings {
             };
 
             self.to_id.insert(hashable.seahash(), id);
-            self.to_string.push(hashable.to_spanned_string());
+            self.to_string.push(hashable.to_seahashed_string());
             id
         }
     }
@@ -85,12 +85,7 @@ impl ModuleTable {
     }
 
     pub fn values(&self) -> Vec<String> {
-        self.strings
-            .to_string
-            .iter()
-            .cloned()
-            .map(|s| s.0)
-            .collect()
+        self.strings.to_string.iter().cloned().collect()
     }
 }
 
@@ -130,7 +125,7 @@ impl Environment<'parent> {
 
 pub trait Seahash {
     fn seahash(&self) -> u64;
-    fn to_spanned_string(&self) -> Spanned<String>;
+    fn to_seahashed_string(&self) -> String;
 }
 
 impl Seahash for String {
@@ -138,8 +133,8 @@ impl Seahash for String {
         seahash::hash(self.as_bytes())
     }
 
-    fn to_spanned_string(&self) -> Spanned<String> {
-        Spanned::synthetic(self.clone())
+    fn to_seahashed_string(&self) -> String {
+        self.clone()
     }
 }
 
@@ -148,8 +143,8 @@ impl Seahash for str {
         seahash::hash(self.as_bytes())
     }
 
-    fn to_spanned_string(&self) -> Spanned<String> {
-        Spanned::synthetic(self.to_string())
+    fn to_seahashed_string(&self) -> String {
+        self.to_string()
     }
 }
 
@@ -158,8 +153,8 @@ impl Seahash for &str {
         seahash::hash(self.as_bytes())
     }
 
-    fn to_spanned_string(&self) -> Spanned<String> {
-        Spanned::synthetic(self.to_string())
+    fn to_seahashed_string(&self) -> String {
+        self.to_string()
     }
 }
 
@@ -168,8 +163,8 @@ impl Seahash for Spanned<String> {
         seahash::hash(self.0.as_bytes())
     }
 
-    fn to_spanned_string(&self) -> Spanned<String> {
-        self.clone()
+    fn to_seahashed_string(&self) -> String {
+        (**self).clone()
     }
 }
 

--- a/components/parser/src/parser/program.rs
+++ b/components/parser/src/parser/program.rs
@@ -128,26 +128,6 @@ pub trait Seahash {
     fn to_seahashed_string(&self) -> String;
 }
 
-impl Seahash for String {
-    fn seahash(&self) -> u64 {
-        seahash::hash(self.as_bytes())
-    }
-
-    fn to_seahashed_string(&self) -> String {
-        self.clone()
-    }
-}
-
-impl Seahash for str {
-    fn seahash(&self) -> u64 {
-        seahash::hash(self.as_bytes())
-    }
-
-    fn to_seahashed_string(&self) -> String {
-        self.to_string()
-    }
-}
-
 impl Seahash for &str {
     fn seahash(&self) -> u64 {
         seahash::hash(self.as_bytes())
@@ -155,16 +135,6 @@ impl Seahash for &str {
 
     fn to_seahashed_string(&self) -> String {
         self.to_string()
-    }
-}
-
-impl Seahash for Spanned<String> {
-    fn seahash(&self) -> u64 {
-        seahash::hash(self.0.as_bytes())
-    }
-
-    fn to_seahashed_string(&self) -> String {
-        (**self).clone()
     }
 }
 

--- a/components/parser/src/parser/program.rs
+++ b/components/parser/src/parser/program.rs
@@ -13,6 +13,8 @@ pub struct StringId {
     position: usize,
 }
 
+debug::debug_fallback_impl!(StringId);
+
 pub trait LookupStringId {
     fn lookup(&self, id: StringId) -> Arc<String>;
 }


### PR DESCRIPTION
I was working towards moving everything onto one intern + debug infrastructure. Didn't quite get there, but here is how far I got.

Most notable thing:

You can now do `#[derive(Debug, DebugWith)]` to get the `debug_with` helpers. This relies on specialization so you need to add that feature. Note that all types must implement `DebugWith` for **any** context. This means that if you want to have a specialized `DebugWith` impl, you also need a fallback -- the macro `debug::debug_fallback_impl` helpfully provides such a fallback for you, using `std::fmt::Debug`.

