### PR TITLE
Add in query system with salsa support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
  "pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "query 0.1.0",
  "salsa 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smart-default 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -526,6 +527,18 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "query"
+version = "0.1.0"
+dependencies = [
+ "ast 0.1.0",
+ "intern 0.1.0",
+ "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parser 0.1.0",
+ "salsa 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "task_manager 0.1.0",
 ]
 
 [[package]]
@@ -770,6 +783,7 @@ version = "0.1.0"
 dependencies = [
  "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mir 0.1.0",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ authors = [
 edition = '2018'
 
 [workspace]
-members = [
-    "components/ide",
-]
 
 [dependencies]
 codespan = "0.1.3"
@@ -43,6 +40,7 @@ lark-string = { path = "components/lark-string" }
 mir = { path = "components/mir" }
 map = { path = "components/map" }
 parser = { path = "components/parser" }
+query = { path = "components/query" }
 task_manager = { path = "components/task_manager" }
 ty = { path = "components/ty" }
 type-check = { path = "components/type-check" }

--- a/components/ast/src/lib.rs
+++ b/components/ast/src/lib.rs
@@ -7,8 +7,8 @@
 #![feature(specialization)]
 
 use crate::item_id::ItemId;
-use crate::item_id::ItemIdTables;
-use crate::parser_state::ParserState;
+pub use crate::item_id::ItemIdTables;
+pub use crate::parser_state::ParserState;
 use intern::Has;
 pub use parser::ast;
 use parser::ParseError;

--- a/components/ast/src/parser_state.rs
+++ b/components/ast/src/parser_state.rs
@@ -21,7 +21,7 @@ impl ParserState {
         parser::parse(Cow::Borrowed(&*input_text), &mut module_table, 0)
     }
 
-    pub fn untern_string(&self, string_id: StringId) -> Arc<String> {
+    crate fn untern_string(&self, string_id: StringId) -> Arc<String> {
         Arc::new(self.module_table.read().lookup(&string_id).to_string())
     }
 

--- a/components/ast/src/parser_state.rs
+++ b/components/ast/src/parser_state.rs
@@ -21,7 +21,7 @@ impl ParserState {
         parser::parse(Cow::Borrowed(&*input_text), &mut module_table, 0)
     }
 
-    crate fn untern_string(&self, string_id: StringId) -> Arc<String> {
+    pub fn untern_string(&self, string_id: StringId) -> Arc<String> {
         Arc::new(self.module_table.read().lookup(&string_id).to_string())
     }
 

--- a/components/query/Cargo.toml
+++ b/components/query/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "query"
+version = "0.1.0"
+authors = ["Jonathan Turner <jonathan.d.turner@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+languageserver-types = "0.51.0"
+salsa = "0.5.0"
+
+ast = { path = "../ast" }
+intern = { path = "../intern" }
+parser = { path = "../parser" }
+task_manager = { path = "../task_manager" }

--- a/components/query/src/lib.rs
+++ b/components/query/src/lib.rs
@@ -35,7 +35,7 @@ salsa::database_storage! {
 
 impl parser::LookupStringId for LarkDatabase {
     fn lookup(&self, id: parser::StringId) -> Arc<String> {
-        self.parser_state.untern_string(id)
+        self.untern_string(id)
     }
 }
 

--- a/components/query/src/lib.rs
+++ b/components/query/src/lib.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use ast::{
+    AstDatabase, AstOfFile, AstOfItem, HasParserState, InputFiles, InputText, ItemIdTables,
+    ItemsInFile, ParserState,
+};
+use intern::Has;
+use salsa::Database;
+use task_manager::{Actor, QueryRequest, QueryResponse};
+
+#[derive(Default)]
+struct LarkDatabase {
+    runtime: salsa::Runtime<LarkDatabase>,
+    parser_state: ParserState,
+    item_id_tables: ItemIdTables,
+}
+
+impl salsa::Database for LarkDatabase {
+    fn salsa_runtime(&self) -> &salsa::Runtime<LarkDatabase> {
+        &self.runtime
+    }
+}
+
+salsa::database_storage! {
+    struct LarkDatabaseStorage for LarkDatabase {
+        impl AstDatabase {
+            fn input_files() for InputFiles;
+            fn input_text() for InputText;
+            fn ast_of_file() for AstOfFile;
+            fn items_in_file() for ItemsInFile;
+            fn ast_of_item() for AstOfItem;
+        }
+    }
+}
+
+impl parser::LookupStringId for LarkDatabase {
+    fn lookup(&self, id: parser::StringId) -> Arc<String> {
+        self.parser_state.untern_string(id)
+    }
+}
+
+impl Has<ItemIdTables> for LarkDatabase {
+    fn intern_tables(&self) -> &ItemIdTables {
+        &self.item_id_tables
+    }
+}
+
+impl HasParserState for LarkDatabase {
+    fn parser_state(&self) -> &ParserState {
+        &self.parser_state
+    }
+}
+
+pub struct QuerySystem {
+    send_channel: Option<Box<dyn Fn(QueryResponse) -> () + Send>>,
+    lark_db: LarkDatabase,
+}
+
+impl QuerySystem {
+    pub fn new() -> QuerySystem {
+        QuerySystem {
+            send_channel: None,
+            lark_db: LarkDatabase::default(),
+        }
+    }
+}
+
+impl Actor for QuerySystem {
+    type InMessage = QueryRequest;
+    type OutMessage = QueryResponse;
+
+    fn startup(&mut self, send_channel: Box<dyn Fn(Self::OutMessage) -> () + Send>) {
+        self.send_channel = Some(send_channel);
+    }
+
+    fn shutdown(&mut self) {}
+
+    fn receive_message(&mut self, message: Self::InMessage) {
+        match message {
+            QueryRequest::OpenFile(url, contents) => {
+                let interned_path = self.lark_db.intern_string(url.as_str());
+                let interned_contents = self.lark_db.intern_string(contents.as_str());
+                self.lark_db
+                    .query(InputFiles)
+                    .set((), Arc::new(vec![interned_path]));
+                self.lark_db
+                    .query(InputText)
+                    .set(interned_path, Some(interned_contents));
+            }
+            QueryRequest::EditFile(_) => {}
+            QueryRequest::TypeAtPosition(task_id, url, _position) => {
+                let interned_path = self.lark_db.intern_string(url.as_str());
+                let result = self.lark_db.query(InputText).get(interned_path);
+
+                let contents = self.lark_db.untern_string(result.unwrap());
+                match self.send_channel {
+                    Some(ref c) => c(QueryResponse::Type(task_id, contents.to_string())),
+                    None => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/components/task_manager/Cargo.toml
+++ b/components/task_manager/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 languageserver-types = "0.51.0"
 mir = { path = "../mir" }
+url = "1.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ mod tests;
 use std::{env, io};
 
 use ide::{lsp_serve, LspResponder};
-use task_manager::{Actor, FakeTypeChecker};
+use query::QuerySystem;
+use task_manager::Actor;
 
 fn build(_filename: &str) {}
 
@@ -29,10 +30,10 @@ fn run(_filename: &str) {}
 fn repl() {}
 
 fn ide() {
-    let type_checker = FakeTypeChecker::new();
+    let query_system = QuerySystem::new();
     let lsp_responder = LspResponder;
 
-    let task_manager = task_manager::TaskManager::spawn(type_checker, lsp_responder);
+    let task_manager = task_manager::TaskManager::spawn(query_system, lsp_responder);
 
     lsp_serve(task_manager.channel);
     let _ = task_manager.join_handle.join();


### PR DESCRIPTION
This PR adds a query system, based on the existing salsa support, that can handle queries from the LSP side. Currently, the only thing it can do is open a file with known contents, and to return these on a hover request.