### PR TITLE
Bump the required VSCode version

### DIFF
--- a/lark/client/package.json
+++ b/lark/client/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/lark-exploration/lark"
 	},
 	"engines": {
-		"vscode": "^1.23.0"
+		"vscode": "^1.25.0"
 	},
 	"scripts": {
 		"update-vscode": "vscode-install",

--- a/lark/package.json
+++ b/lark/package.json
@@ -14,7 +14,7 @@
 		"multi-root ready"
 	],
 	"engines": {
-		"vscode": "^1.23.0"
+		"vscode": "^1.25.0"
 	},
 	"activationEvents": [
 		"onLanguage:lark"


### PR DESCRIPTION
Bump the required VSCode version to prevent errors in dependent .d.ts files.