### PR TITLE
Fix `msg` typo in sample code

### DIFF
--- a/samples/challenge1.lark
+++ b/samples/challenge1.lark
@@ -4,7 +4,7 @@ struct Diagnostic {
 }
 
 def new(msg: own String, level: String) -> Diagnostic {
-  Diagnostic { mgs, level }
+  Diagnostic { msg, level }
 }
 
 def main() {


### PR DESCRIPTION
Unless this was intended, to show an error for this subtle mistake ?