### PR TITLE
Add support for C codegen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ os:
   - linux
   - osx
   - windows
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"; fi


### PR DESCRIPTION
This PR adds basic support for C-based codegen. Currently, the functionality is limited to working with simple types and structs. 

C-based building currently uses MSVC on Windows and clang for Unix-based systems.

This PR removes string interp from the MIR. This will likely be added back to an earlier compiler stage once more support is in place.