### PR TITLE
Add C codegen support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ os:
   - linux
   - osx
   - windows
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"; fi  

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,4 @@ matrix:
 os:
   - linux
   - osx
-  - windows
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"; fi  
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ os:
   - osx
   - windows
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"; fi  
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"; fi  

--- a/components/lark-codegen/src/build.rs
+++ b/components/lark-codegen/src/build.rs
@@ -7,7 +7,7 @@ pub fn build(
 ) -> std::io::Result<()> {
     match codegen_type {
         CodegenType::Rust => build_rust(target_filename, src),
-        CodegenType::C => unimplemented!("C output not yet supported"),
+        CodegenType::C => build_c(target_filename, src),
     }
 }
 
@@ -44,6 +44,75 @@ fn build_rust(target_filename: &str, src: &String) -> std::io::Result<()> {
         .arg(target_filename)
         .output()
         .expect("Failed to run Rust compiler");
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        use std::io::{Error, ErrorKind};
+
+        let compile_stdout = String::from_utf8(output.stdout).unwrap();
+        let compile_stderr = String::from_utf8(output.stderr).unwrap();
+
+        let combined_compile_msg = compile_stdout + &compile_stderr;
+
+        Err(Error::new(ErrorKind::Other, combined_compile_msg))
+    }
+}
+
+#[cfg(windows)]
+fn build_c(target_filename: &str, src: &String) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::process::Command;
+
+    let mut src_file = create_src_file(CodegenType::C);
+    src_file.write_all(src.as_bytes()).unwrap();
+    let _ = src_file.flush();
+    let src_file_name = src_file.path().to_string_lossy().to_string();
+    let _ = src_file.persist(&src_file_name);
+
+    let output = Command::new(r"cl.exe")
+        .arg("/w")
+        .arg(&format!("/Fo{}.obj", target_filename))
+        .arg(&format!("/Fe{}", target_filename))
+        .arg(&src_file_name)
+        .output()
+        .expect("Failed to run C compiler");
+
+    let _ = std::fs::remove_file(src_file_name);
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        use std::io::{Error, ErrorKind};
+
+        let compile_stdout = String::from_utf8(output.stdout).unwrap();
+        let compile_stderr = String::from_utf8(output.stderr).unwrap();
+
+        let combined_compile_msg = compile_stdout + &compile_stderr;
+
+        Err(Error::new(ErrorKind::Other, combined_compile_msg))
+    }
+}
+
+#[cfg(unix)]
+fn build_c(target_filename: &str, src: &String) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::process::Command;
+
+    let mut src_file = create_src_file(CodegenType::C);
+    src_file.write_all(src.as_bytes()).unwrap();
+    let _ = src_file.flush();
+    let src_file_name = src_file.path().to_string_lossy().to_string();
+    let _ = src_file.persist(&src_file_name);
+
+    let output = Command::new(r"clang")
+        .arg(&src_file_name)
+        .arg("-o")
+        .arg(&target_filename)
+        .output()
+        .expect("Failed to run C compiler");
+
+    let _ = std::fs::remove_file(src_file_name);
 
     if output.status.success() {
         Ok(())

--- a/components/lark-codegen/src/codegen_c.rs
+++ b/components/lark-codegen/src/codegen_c.rs
@@ -1,0 +1,328 @@
+use lark_mir::{
+    builtin_type, BasicBlock, BinOp, Context, Definition, Function, Operand, Place, Rvalue,
+    StatementKind, Struct, Terminator, TerminatorKind, Ty, VarId,
+};
+
+pub struct CFile {
+    output_src: String,
+}
+
+impl CFile {
+    pub fn output_raw(&mut self, output: &str) {
+        self.output_src += output;
+    }
+
+    pub fn new() -> CFile {
+        CFile {
+            output_src: String::new(),
+        }
+    }
+
+    pub fn render(self) -> String {
+        self.output_src
+    }
+}
+
+fn build_type(context: &Context, ty: Ty) -> String {
+    match context.get_def_id_for_ty(ty) {
+        Some(builtin_type::I32) => "int".into(),
+        Some(builtin_type::VOID) => "void".into(),
+        Some(builtin_type::STRING) => "char*".into(),
+        Some(def_id) => match &context.definitions[def_id] {
+            Definition::Struct(s) => format!("struct struct_{}", s.name),
+            _ => unimplemented!("Can't build name for definition"),
+        },
+        _ => unimplemented!("Can't build name for definition"),
+    }
+}
+
+fn build_var_name(f: &Function, var_id: VarId) -> String {
+    match &f.local_decls[var_id].name {
+        Some(n) => n.clone(),
+        None => format!("_tmp_{}", var_id,),
+    }
+}
+
+fn build_operand(f: &Function, operand: &Operand) -> String {
+    match operand {
+        Operand::ConstantInt(i) => format!("{}", i),
+        Operand::ConstantString(s) => format!("\"{}\"", s),
+        Operand::Copy(place) | Operand::Move(place) => match place {
+            Place::Local(var_id) => format!("{}", build_var_name(f, *var_id)),
+            _ => unimplemented!("Copy of non-local value"),
+        },
+    }
+}
+
+fn build_print_based_on_type(context: &Context, name: &str, ty: Ty) -> String {
+    match context.get_def_id_for_ty(ty) {
+        Some(builtin_type::I32) => format!("printf(\"%i\\n\", {});\n", name),
+        Some(builtin_type::STRING) => format!("printf(\"%s\\n\", {});\n", name),
+        _ => unimplemented!("Unsupported type for debug print in C: {:?}", ty),
+    }
+}
+
+fn codegen_block(c_file: &mut CFile, context: &Context, f: &Function, b: &BasicBlock) {
+    for stmt in &b.statements {
+        match &stmt.kind {
+            StatementKind::Assign(lhs, rhs) => {
+                match lhs {
+                    Place::Local(var_id) => {
+                        c_file.output_raw(&format!("{} = ", build_var_name(f, *var_id)));
+                    }
+                    Place::Static(_) => unimplemented!("Assignment into static place"),
+                    Place::Field(var_id, field_name) => {
+                        c_file.output_raw(&format!(
+                            "{}.{} = ",
+                            build_var_name(f, *var_id),
+                            field_name
+                        ));
+                    }
+                };
+                match rhs {
+                    Rvalue::Use(operand) => {
+                        let operand_name = build_operand(f, operand);
+                        c_file.output_raw(&operand_name)
+                    }
+                    Rvalue::BinaryOp(bin_op, lhs, rhs) => {
+                        let op = match bin_op {
+                            BinOp::Add => "+",
+                            BinOp::Sub => "-",
+                        };
+
+                        c_file.output_raw(&format!(
+                            "{} {} {}",
+                            build_var_name(f, *lhs),
+                            op,
+                            build_var_name(f, *rhs)
+                        ));
+                    }
+                    Rvalue::Call(def_id, args) => {
+                        let mut processed_args = vec![];
+                        for arg in args {
+                            processed_args.push(build_operand(f, arg));
+                        }
+                        match &context.definitions[*def_id] {
+                            Definition::Fn(f) => {
+                                c_file.output_raw(&format!("{}(", f.name));
+                                let mut first = true;
+                                for processed_arg in processed_args {
+                                    if !first {
+                                        c_file.output_raw(", ");
+                                    } else {
+                                        first = false;
+                                    }
+                                    c_file.output_raw(&processed_arg);
+                                }
+                                c_file.output_raw(")");
+                            }
+                            Definition::Struct(s) => {
+                                c_file.output_raw(&format!("_init_struct_{}(", s.name));
+                                let mut first = true;
+                                for processed_arg in processed_args {
+                                    if !first {
+                                        c_file.output_raw(", ");
+                                    } else {
+                                        first = false;
+                                    }
+                                    c_file.output_raw(&processed_arg);
+                                }
+                                c_file.output_raw(")");
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                c_file.output_raw(";\n");
+            }
+            StatementKind::DebugPrint(place) => match place {
+                Place::Local(var_id) => {
+                    let var_name = build_var_name(f, *var_id);
+                    c_file.output_raw(&build_print_based_on_type(
+                        context,
+                        &var_name,
+                        f.local_decls[*var_id].ty,
+                    ));
+                }
+                Place::Field(var_id, field_name) => {
+                    match context.get_def_id_for_ty(f.local_decls[*var_id].ty) {
+                        Some(def_id) => match &context.definitions[def_id] {
+                            lark_mir::Definition::Struct(s) => {
+                                let mut found = false;
+                                for field in &s.fields {
+                                    if &field.name == field_name {
+                                        c_file.output_raw(&build_print_based_on_type(
+                                            context,
+                                            &format!(
+                                                "{}.{}",
+                                                build_var_name(f, *var_id),
+                                                field_name
+                                            ),
+                                            field.ty,
+                                        ));
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if !found {
+                                    panic!("Can not find matching field for {}", field_name);
+                                }
+                            }
+                            _ => panic!("Field access on non-struct"),
+                        },
+                        None => panic!("Can't find struct for field access"),
+                    }
+                }
+                _ => unimplemented!("Can't output: {:?}", place),
+            },
+        }
+    }
+    match b.terminator {
+        Some(Terminator {
+            kind: TerminatorKind::Return,
+            ..
+        }) => match context.get_def_id_for_ty(f.local_decls[0].ty) {
+            Some(builtin_type::VOID) => c_file.output_raw("return;\n"),
+            _ => c_file.output_raw(&format!("return({});\n", build_var_name(f, 0))),
+        },
+        None => {}
+    }
+}
+
+fn codegen_fn_predecl(c_file: &mut CFile, context: &Context, f: &Function) {
+    c_file.output_raw(&format!(
+        "{} {} (",
+        build_type(context, f.local_decls[0].ty),
+        f.name
+    ));
+    let mut after_first = false;
+    for param in f.local_decls.iter().skip(1).take(f.arg_count) {
+        if after_first {
+            c_file.output_raw(", ");
+        } else {
+            after_first = true;
+        }
+        c_file.output_raw(&build_type(context, param.ty));
+        c_file.output_raw(" ");
+        c_file.output_raw(&param.name.clone().unwrap());
+    }
+    c_file.output_raw(");\n");
+}
+
+fn codegen_struct_predecl(c_file: &mut CFile, _context: &Context, s: &Struct) {
+    c_file.output_raw(&format!("struct struct_{};\n", s.name));
+    c_file.output_raw(&format!(
+        "struct struct_{} _init_struct_{}();\n",
+        s.name, s.name
+    ));
+}
+
+fn codegen_fn(c_file: &mut CFile, context: &Context, f: &Function) {
+    c_file.output_raw(&format!(
+        "{} {} (",
+        build_type(context, f.local_decls[0].ty),
+        f.name
+    ));
+    let mut after_first = false;
+    for param in f.local_decls.iter().skip(1).take(f.arg_count) {
+        if after_first {
+            c_file.output_raw(", ");
+        } else {
+            after_first = true;
+        }
+        c_file.output_raw(&build_type(context, param.ty));
+        c_file.output_raw(" ");
+        c_file.output_raw(&param.name.clone().unwrap());
+    }
+    c_file.output_raw(")");
+
+    c_file.output_raw("\n{\n");
+    for (idx, local_decl) in f.local_decls.iter().enumerate().skip(1 + f.arg_count) {
+        c_file.output_raw(&format!(
+            "{} {};\n",
+            build_type(context, local_decl.ty),
+            build_var_name(f, idx),
+        ));
+    }
+
+    match context.get_def_id_for_ty(f.local_decls[0].ty) {
+        Some(builtin_type::VOID) => {}
+        _ => {
+            c_file.output_raw(&format!(
+                "{} {};\n",
+                build_type(context, f.local_decls[0].ty),
+                build_var_name(f, 0),
+            ));
+        }
+    }
+
+    for block in &f.basic_blocks {
+        codegen_block(c_file, context, f, block);
+    }
+
+    c_file.output_raw("}\n");
+}
+
+fn codegen_struct(c_file: &mut CFile, context: &Context, s: &Struct) {
+    c_file.output_raw(&format!("struct struct_{} {{\n", s.name));
+    for field in &s.fields {
+        c_file.output_raw(&format!(
+            "{} {};\n",
+            build_type(context, field.ty),
+            field.name,
+        ));
+    }
+    c_file.output_raw("};\n");
+    c_file.output_raw(&format!(
+        "struct struct_{} _init_struct_{}(",
+        s.name, s.name
+    ));
+    let mut first = true;
+    for field in &s.fields {
+        if !first {
+            c_file.output_raw(", ");
+        } else {
+            first = false;
+        }
+        c_file.output_raw(&format!("{} {}", build_type(context, field.ty), field.name,));
+    }
+    c_file.output_raw(")\n{\n");
+    c_file.output_raw(&format!("struct struct_{} temp = {{", s.name));
+    let mut first = true;
+    for field in &s.fields {
+        c_file.output_raw(&format!("{}{}", if !first { ", " } else { "" }, field.name,));
+        first = false;
+    }
+    c_file.output_raw("};\n");
+    c_file.output_raw("return temp;\n");
+    c_file.output_raw("}\n");
+}
+
+pub fn codegen_c(context: &Context) -> String {
+    let mut c_file = CFile::new();
+
+    for definition in &context.definitions {
+        match definition {
+            Definition::Fn(f) => {
+                codegen_fn_predecl(&mut c_file, context, f);
+            }
+            Definition::Struct(s) => {
+                codegen_struct_predecl(&mut c_file, context, s);
+            }
+            _ => {}
+        }
+    }
+    for definition in &context.definitions {
+        match definition {
+            Definition::Fn(f) => {
+                codegen_fn(&mut c_file, context, f);
+            }
+            Definition::Struct(s) => {
+                codegen_struct(&mut c_file, context, s);
+            }
+            _ => {}
+        }
+    }
+
+    c_file.render()
+}

--- a/components/lark-codegen/src/codegen_rust.rs
+++ b/components/lark-codegen/src/codegen_rust.rs
@@ -1,6 +1,6 @@
 use lark_mir::{
-    builtin_type, BasicBlock, BinOp, BuiltinFn, Context, Definition, Function, Operand, Place,
-    Rvalue, StatementKind, Struct, Terminator, TerminatorKind, Ty, VarId,
+    builtin_type, BasicBlock, BinOp, Context, Definition, Function, Operand, Place, Rvalue,
+    StatementKind, Struct, Terminator, TerminatorKind, Ty, VarId,
 };
 
 pub struct RustFile {
@@ -105,21 +105,6 @@ fn codegen_block(rust: &mut RustFile, context: &Context, f: &Function, b: &Basic
                                 }
                                 rust.output_raw(")");
                             }
-                            Definition::BuiltinFn(builtin_fn) => match builtin_fn {
-                                BuiltinFn::StringInterpolate => {
-                                    rust.output_raw("format!(");
-                                    let mut first = true;
-                                    for processed_arg in processed_args {
-                                        if !first {
-                                            rust.output_raw(", ");
-                                        } else {
-                                            first = false;
-                                        }
-                                        rust.output_raw(&processed_arg);
-                                    }
-                                    rust.output_raw(")");
-                                }
-                            },
                             Definition::Struct(s) => {
                                 rust.output_raw(&format!("{} {{", s.name));
                                 for i in 0..s.fields.len() {

--- a/components/lark-codegen/src/lib.rs
+++ b/components/lark-codegen/src/lib.rs
@@ -1,6 +1,7 @@
 use lark_mir::Context;
 
 mod build;
+mod codegen_c;
 mod codegen_rust;
 
 #[derive(Copy, Clone)]
@@ -12,7 +13,7 @@ pub enum CodegenType {
 pub fn codegen(context: &Context, codegen_type: CodegenType) -> String {
     match codegen_type {
         CodegenType::Rust => codegen_rust::codegen_rust(context),
-        CodegenType::C => unimplemented!("C codegen not yet supported"),
+        CodegenType::C => codegen_c::codegen_c(context),
     }
 }
 

--- a/components/lark-eval/src/lib.rs
+++ b/components/lark-eval/src/lib.rs
@@ -1,6 +1,5 @@
 use lark_mir::{
-    BinOp, BuiltinFn, Context, DefId, Definition, Function, Operand, Place, Rvalue, Statement,
-    StatementKind,
+    BinOp, Context, DefId, Definition, Function, Operand, Place, Rvalue, Statement, StatementKind,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -82,33 +81,6 @@ fn eval_rvalue(context: &Context, frame: &mut CallFrame, rvalue: &Rvalue) -> Val
                     eval_fn(context, &mut new_frame, f);
                     let result = new_frame.locals[0].clone();
                     result
-                }
-                Definition::BuiltinFn(BuiltinFn::StringInterpolate) => {
-                    let mut arg_eval = vec![];
-                    for arg in args {
-                        arg_eval.push(eval_operand(context, frame, arg));
-                    }
-
-                    let format_string = &arg_eval[0];
-
-                    match format_string {
-                        Value::Str(s) => {
-                            let sections: Vec<&str> = s.split("{}").collect();
-                            let sections_len = sections.len();
-
-                            let mut result = String::new();
-
-                            for i in 0..(sections_len - 1) {
-                                result += sections[i];
-                                result += &format!("{}", arg_eval[i + 1]);
-                            }
-
-                            result += sections[sections_len - 1];
-
-                            Value::Str(result)
-                        }
-                        _ => unimplemented!("String interpolation without a format string"),
-                    }
                 }
                 Definition::Struct(ref s) => {
                     let mut new_obj = HashMap::new();

--- a/components/lark-mir/src/lib.rs
+++ b/components/lark-mir/src/lib.rs
@@ -191,14 +191,8 @@ pub mod builtin_type {
 }
 
 #[derive(Debug)]
-pub enum BuiltinFn {
-    StringInterpolate,
-}
-
-#[derive(Debug)]
 pub enum Definition {
     Builtin,
-    BuiltinFn(BuiltinFn),
     Fn(Function),
     Struct(Struct),
 }
@@ -214,8 +208,6 @@ impl Context {
         for _ in 0..(builtin_type::ERROR + 1) {
             definitions.push(Definition::Builtin); // UNKNOWN
         }
-
-        definitions.push(Definition::BuiltinFn(BuiltinFn::StringInterpolate));
 
         Context { definitions }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,12 +3,45 @@ use lark_mir::{
     Place, Rvalue, StatementKind, Struct, TerminatorKind,
 };
 
+pub fn generate_simple_add_test() -> (Context, DefId) {
+    let mut context = Context::new();
+
+    let void_ty = context.simple_type_for_def_id(builtin_type::VOID);
+    let i32_ty = context.simple_type_for_def_id(builtin_type::I32);
+
+    let mut m = Function::new(void_ty, vec![], "main".into());
+    let add_result_tmp = m.new_temp(i32_ty);
+    let lhs_tmp = m.new_temp(i32_ty);
+    let rhs_tmp = m.new_temp(i32_ty);
+
+    let mut bb1 = BasicBlock::new();
+    bb1.push_stmt(StatementKind::Assign(
+        Place::Local(lhs_tmp),
+        Rvalue::Use(Operand::ConstantInt(11)),
+    ));
+    bb1.push_stmt(StatementKind::Assign(
+        Place::Local(rhs_tmp),
+        Rvalue::Use(Operand::ConstantInt(7)),
+    ));
+
+    bb1.push_stmt(StatementKind::Assign(
+        Place::Local(add_result_tmp),
+        Rvalue::BinaryOp(BinOp::Add, lhs_tmp, rhs_tmp),
+    ));
+    bb1.push_stmt(StatementKind::DebugPrint(Place::Local(add_result_tmp)));
+    bb1.terminate(TerminatorKind::Return);
+    m.push_block(bb1);
+
+    let main_def_id = context.add_definition(Definition::Fn(m));
+
+    (context, main_def_id)
+}
+
 pub fn generate_big_test() -> (Context, DefId) {
     let mut context = Context::new();
 
     let i32_ty = context.simple_type_for_def_id(builtin_type::I32);
     let void_ty = context.simple_type_for_def_id(builtin_type::VOID);
-    let string_ty = context.simple_type_for_def_id(builtin_type::STRING);
 
     let mut bob = Function::new(
         i32_ty,
@@ -47,7 +80,6 @@ pub fn generate_big_test() -> (Context, DefId) {
 
     let mut m = Function::new(void_ty, vec![], "main".into());
     let call_result_tmp = m.new_temp(i32_ty);
-    let interp_result_tmp = m.new_temp(string_ty);
     let person_result_tmp = m.new_temp(person_ty);
 
     let mut bb2 = BasicBlock::new();
@@ -60,18 +92,7 @@ pub fn generate_big_test() -> (Context, DefId) {
         ),
     ));
 
-    bb2.push_stmt(StatementKind::Assign(
-        Place::Local(interp_result_tmp),
-        Rvalue::Call(
-            101, /*builtin string interp*/
-            vec![
-                Operand::ConstantString("Hello, world {}".into()),
-                Operand::Move(Place::Local(call_result_tmp)),
-            ],
-        ),
-    ));
-
-    bb2.push_stmt(StatementKind::DebugPrint(Place::Local(interp_result_tmp)));
+    bb2.push_stmt(StatementKind::DebugPrint(Place::Local(call_result_tmp)));
 
     bb2.push_stmt(StatementKind::Assign(
         Place::Local(person_result_tmp),

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -3,17 +3,21 @@ mod common;
 #[cfg(test)]
 mod tests {
     use lark_codegen::{build, codegen, CodegenType};
+    use lark_mir::{Context, DefId};
     use std::process::Command;
 
-    #[test]
-    fn build_big_test_in_rust() {
-        let (context, _) = crate::common::generate_big_test();
-        let src = codegen(&context, CodegenType::Rust);
+    fn run_compile_test(
+        filename: &str,
+        codegen_type: CodegenType,
+        full_context: (Context, DefId),
+        expected: &str,
+    ) {
+        let src = codegen(&full_context.0, codegen_type);
 
         let mut out_path = std::env::temp_dir();
-        out_path.push("codegen_simple");
+        out_path.push(filename);
 
-        let result = build(out_path.to_str().unwrap(), &src, CodegenType::Rust);
+        let result = build(out_path.to_str().unwrap(), &src, codegen_type);
         result.unwrap();
         let output = Command::new(out_path.to_str().unwrap())
             .output()
@@ -21,6 +25,70 @@ mod tests {
 
         let output_stdout = String::from_utf8_lossy(&output.stdout);
 
-        assert_eq!(output_stdout, "\"Hello, world 3\"\n18\n");
+        assert_eq!(output_stdout, expected);
+    }
+
+    #[test]
+    fn build_big_test_in_rust() {
+        run_compile_test(
+            "big_test_in_rust",
+            CodegenType::Rust,
+            crate::common::generate_big_test(),
+            "3\n18\n",
+        );
+    }
+
+    #[test]
+    fn build_simple_add_test_in_rust() {
+        run_compile_test(
+            "simple_add_test_in_rust",
+            CodegenType::Rust,
+            crate::common::generate_simple_add_test(),
+            "18\n",
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn build_simple_add_test_in_c() {
+        run_compile_test(
+            "simple_add_test_in_c",
+            CodegenType::C,
+            crate::common::generate_simple_add_test(),
+            "18\r\n",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_simple_add_test_in_c() {
+        run_compile_test(
+            "simple_add_test_in_c",
+            CodegenType::C,
+            crate::common::generate_simple_add_test(),
+            "18\n",
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn build_big_test_in_c() {
+        run_compile_test(
+            "big_test_in_c",
+            CodegenType::C,
+            crate::common::generate_big_test(),
+            "3\r\n18\r\n",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_big_test_in_c() {
+        run_compile_test(
+            "big_test_in_c",
+            CodegenType::C,
+            crate::common::generate_big_test(),
+            "3\n18\n",
+        );
     }
 }


### PR DESCRIPTION
This PR adds C codegen support to Unix and Windows. The support is still very basic and currently only supports basic types and structs.

This PR also removes string interpolation from the MIR, as it was decided this was not the best place for it. The intent will be to add it back at a later time as systems mature.