### PR TITLE
Add support for error reporting to lsp

### DIFF
--- a/components/lark-task-manager/src/lib.rs
+++ b/components/lark-task-manager/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use url::Url;
 
-use languageserver_types::Position;
+use languageserver_types::{Position, Range};
 
 pub type TaskId = usize;
 
@@ -22,6 +22,7 @@ pub enum LspResponse {
     Type(TaskId, String),
     Completions(TaskId, Vec<(String, String)>),
     Initialized(TaskId),
+    Diagnostics(Url, Vec<(Range, String)>),
 }
 
 pub enum MsgToManager {


### PR DESCRIPTION
This starts laying in some of the basics for reporting errors back to the IDE. So far, this is just the LSP piece, and a way to communicate through the LSP support. It does this by introducing a new Diagnostics member to LSPResponse. It should, in theory, be safe to send these whenever we encounter an error.