### PR TITLE
Remove potentially dangerous vscode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "editor.formatOnSave": true,
-    "rust-client.updateOnStartup": true,
     "rust.all_features": true,
     "rust.build_on_save": true,
     "rust.goto_def_racer_fallback": true


### PR DESCRIPTION
I've had issues with RLS auto-updating the tools. Removing for now to help prevent broken rustup states.