### PR TITLE
Add error reporting to IDE. Also add file edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "salsa 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ty 0.1.0",
  "type-check 0.1.0",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/lark-query-system/Cargo.toml
+++ b/components/lark-query-system/Cargo.toml
@@ -19,3 +19,4 @@ parser = { path = "../parser" }
 salsa = "0.6.2"
 ty = { path = "../ty" }
 type-check = { path = "../type-check" }
+url = "1.7"

--- a/components/lark-query-system/src/lib.rs
+++ b/components/lark-query-system/src/lib.rs
@@ -1,5 +1,5 @@
 use ast::{HasParserState, InputText, ParserState};
-use codespan::{CodeMap, FileMap, FileName};
+use codespan::{CodeMap, ColumnIndex, FileMap, FileName, LineIndex};
 use lark_entity::EntityTables;
 use lark_task_manager::{Actor, NoopSendChannel, QueryRequest, QueryResponse, SendChannel};
 use map::FxIndexMap;
@@ -9,6 +9,7 @@ use salsa::{Database, ParallelDatabase};
 use std::borrow::Cow;
 use std::sync::Arc;
 use ty::interners::TyInternTables;
+use url::Url;
 
 mod ls_ops;
 use self::ls_ops::{Cancelled, LsDatabase};
@@ -112,6 +113,32 @@ impl QuerySystem {
             lark_db: LarkDatabase::default(),
         }
     }
+
+    pub fn check_for_errors_and_report(&self) {
+        std::thread::spawn({
+            let db = self.lark_db.fork();
+            let send_channel = self.send_channel.clone_send_channel();
+
+            move || {
+                let _lock = db.salsa_runtime().lock_revision();
+
+                match db.errors_for_project() {
+                    Ok(errors) => {
+                        // loop over hashmap and send messages
+                        for (key, value) in errors {
+                            let url = Url::parse(&key).unwrap();
+                            let ranges_with_default =
+                                value.iter().map(|x| (*x, "Error".to_string())).collect();
+                            send_channel.send(QueryResponse::Diagnostics(url, ranges_with_default));
+                        }
+                    }
+                    Err(Cancelled) => {
+                        // Ignore
+                    }
+                }
+            }
+        });
+    }
 }
 
 impl Actor for QuerySystem {
@@ -158,8 +185,85 @@ impl Actor for QuerySystem {
                         span: Span::from(file_span),
                     }),
                 );
+
+                self.check_for_errors_and_report();
             }
-            QueryRequest::EditFile(_) => {}
+            QueryRequest::EditFile(url, changes) => {
+                // Process sets on the same thread -- this not only gives them priority,
+                // it ensures an overall ordering to edits.
+                let interned_path = self.lark_db.intern_string(url.as_str());
+                let file_maps = self
+                    .lark_db
+                    .file_maps()
+                    .read()
+                    .get(url.as_str())
+                    .unwrap()
+                    .clone();
+
+                let mut current_contents = file_maps.src().to_string();
+
+                let origin_byte_offset =
+                    file_maps.byte_index(LineIndex(0), ColumnIndex(0)).unwrap();
+
+                for change in changes {
+                    let start_position = change.0.start;
+                    let start_byte_offset = file_maps
+                        .byte_index(
+                            LineIndex(start_position.line as u32),
+                            ColumnIndex((start_position.character) as u32),
+                        )
+                        .unwrap();
+
+                    let end_position = change.0.end;
+                    let end_byte_offset = file_maps
+                        .byte_index(
+                            LineIndex(end_position.line as u32),
+                            ColumnIndex((end_position.character) as u32),
+                        )
+                        .unwrap();
+
+                    unsafe {
+                        let vec = current_contents.as_mut_vec();
+                        vec.drain(
+                            (start_byte_offset - origin_byte_offset).to_usize()
+                                ..(end_byte_offset - origin_byte_offset).to_usize(),
+                        );
+                    }
+
+                    current_contents.insert_str(
+                        (start_byte_offset - origin_byte_offset).to_usize(),
+                        &change.1,
+                    );
+                }
+
+                let interned_contents = self.lark_db.intern_string(current_contents.as_str());
+
+                // Uh, adding a "new" file on each change seems a bit ungreat. But good
+                // enough for now.
+                let file_map = self.lark_db.code_map.write().add_filemap(
+                    FileName::Virtual(Cow::Owned(url.to_string())),
+                    current_contents.to_string(),
+                );
+                let file_span = file_map.span();
+                let start_offset = file_map.span().start().to_usize() as u32;
+
+                // Record the filemap for later
+                self.lark_db
+                    .file_maps
+                    .write()
+                    .insert(url.to_string(), file_map);
+
+                self.lark_db.query(ast::InputTextQuery).set(
+                    interned_path,
+                    Some(InputText {
+                        text: interned_contents,
+                        start_offset,
+                        span: Span::from(file_span),
+                    }),
+                );
+
+                self.check_for_errors_and_report();
+            }
             QueryRequest::TypeAtPosition(task_id, url, position) => {
                 std::thread::spawn({
                     let db = self.lark_db.fork();

--- a/samples/challenge1.lark
+++ b/samples/challenge1.lark
@@ -1,6 +1,6 @@
 struct Diagnostic {
   msg: own String,
-  level: String
+  level: String,
 }
 
 def new(msg: own String, level: String) -> Diagnostic {


### PR DESCRIPTION
This plumbs the error reporting from open/edit events back through to the IDE, so we can display when an error occurs. Currently, we don't display any text for the error message and instead use a generic "Error" message.

This PR also adds support for file editing events, and tracks those changes by applying the edits against the existing contents in the filemap.