### PR TITLE
Add some type checking to error reporting

### DIFF
--- a/samples/challenge1.lark
+++ b/samples/challenge1.lark
@@ -1,6 +1,6 @@
 struct Diagnostic {
   msg: own String,
-  level: String,
+  level: String
 }
 
 def new(msg: own String, level: String) -> Diagnostic {


### PR DESCRIPTION
This adds a check for the types of entities and subentities, as well as signatures of files.