### PR TITLE
Add helper functions to build vscode support. Minimize logging

### DIFF
--- a/components/lark-query-system/src/ls_ops.rs
+++ b/components/lark-query-system/src/ls_ops.rs
@@ -114,7 +114,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                     .accumulate_errors_into(errors);
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
-                let _ = self.base_type_check(entity).accumulate_errors_into(errors);
+                //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
             EntityData::MemberName {
                 kind: MemberKind::Method,
@@ -125,7 +125,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                     .accumulate_errors_into(errors);
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
-                let _ = self.base_type_check(entity).accumulate_errors_into(errors);
+                //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
         }
 

--- a/lark/build.bat
+++ b/lark/build.bat
@@ -1,0 +1,1 @@
+npm run buildall

--- a/lark/build.sh
+++ b/lark/build.sh
@@ -1,0 +1,1 @@
+npm run buildall

--- a/lark/package.json
+++ b/lark/package.json
@@ -70,7 +70,8 @@
 		"compile:client": "tsc -p ./client/tsconfig.json",
 		"watch:client": "tsc -w -p ./client/tsconfig.json",
 		"compile": "npm run compile:client",
-		"postinstall": "cd client && npm install && npm install && cd .."
+		"postinstall": "cd client && npm install && npm install && cd ..",
+		"buildall": "npm install && cd client && npm run update-vscode && cd .. && npm run compile"
 	},
 	"devDependencies": {
 		"@types/mocha": "^5.2.0",

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn ide() {
 }
 
 fn main() {
-    Logger::with_env_or_str("debug")
+    Logger::with_env_or_str("error")
         .log_to_file()
         .directory("log_files")
         .format(opt_format)


### PR DESCRIPTION
This PR adds a simpler way of building the vscode support. It also comments out the previous body typechecking, and minimizes logging to only error to prevent large files from overloading vscode.