### PR TITLE
discard messages if there are pending mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ version = "0.1.0"
 dependencies = [
  "languageserver-types 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lark-mir 0.1.0",
+ "map 0.1.0",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "lark-task-manager 0.1.0",
  "lark-ty 0.1.0",
  "lark-type-check 0.1.0",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "map 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
- "salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ dependencies = [
  "map 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
- "salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
  "pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smart-default 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -467,7 +467,7 @@ dependencies = [
  "map 0.1.0",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parser 0.1.0",
- "salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -525,7 +525,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "map 0.1.0",
  "parser 0.1.0",
- "salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "salsa"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1224,7 +1224,7 @@ dependencies = [
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
-"checksum salsa 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef0f1fb2a01d4579b6658343b1b5431a72c62c186ebb9b40bd6cd3078c7afecf"
+"checksum salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e56b13ce9b2bfaa1c89863d76880838c0734de85beeaef437fd70d4fa7e253d3"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ authors = [
 ]
 edition = '2018'
 
+[profile.dev]
+opt-level = 1
+
 [workspace]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ text-diff = "0.4.0"
 languageserver-types = "0.51.0"
 flexi_logger = "0.9.2"
 pretty_env_logger = "0.2"
-salsa = "0.7"
+salsa = "0.8"
 
 debug = { path = "components/debug" }
 indices = { path = "components/indices" }

--- a/components/ast/Cargo.toml
+++ b/components/ast/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 codespan = "0.1.3"
 log = "0.4.5"
 parking_lot = "0.6.4"
-salsa = "0.7"
+salsa = "0.8"
 
 debug = { path = "../debug" }
 lark-debug-derive = { path = "../lark-debug-derive" }

--- a/components/ast/src/test.rs
+++ b/components/ast/src/test.rs
@@ -62,12 +62,12 @@ impl AsRef<EntityTables> for TestDatabaseImpl {
 
 #[test]
 fn parse_error() {
-    let db = TestDatabaseImpl::default();
+    let mut db = TestDatabaseImpl::default();
 
     let path1 = db.intern_string("path1");
-    db.query(InputFilesQuery).set((), Arc::new(vec![path1]));
+    db.query_mut(InputFilesQuery).set((), Arc::new(vec![path1]));
     let text1 = db.intern_string("XXX");
-    db.query(InputTextQuery).set(
+    db.query_mut(InputTextQuery).set(
         path1,
         Some(InputText {
             text: text1,
@@ -81,17 +81,17 @@ fn parse_error() {
 
 #[test]
 fn parse_ok() {
-    let db = TestDatabaseImpl::default();
+    let mut db = TestDatabaseImpl::default();
 
     let path1 = db.intern_string("path1");
-    db.query(InputFilesQuery).set((), Arc::new(vec![path1]));
+    db.query_mut(InputFilesQuery).set((), Arc::new(vec![path1]));
     let text1_str = "struct Diagnostic { msg: own String, level: String, }
 
 def new(msg: own String, level: String) -> Diagnostic {
   Diagnostic { mgs, level }
 }";
     let text1_interned = db.intern_string(text1_str);
-    db.query(InputTextQuery).set(
+    db.query_mut(InputTextQuery).set(
         path1,
         Some(InputText {
             text: text1_interned,

--- a/components/hir/Cargo.toml
+++ b/components/hir/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 log = "0.4.5"
 parking_lot = "0.6.4"
-salsa = "0.7"
+salsa = "0.8"
 
 ast = { path = "../ast" }
 debug = { path = "../debug" }

--- a/components/lark-language-server/src/lib.rs
+++ b/components/lark-language-server/src/lib.rs
@@ -1,6 +1,7 @@
 use lark_task_manager::{self, Actor, LspRequest, LspResponse, MsgToManager, SendChannel};
 use serde::Serialize;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::{Read, Write};
 use std::sync::mpsc::Sender;
@@ -120,8 +121,8 @@ impl Actor for LspResponder {
     /// Receive messages from the task manager that contain the results of
     /// a given task. This allows us to repond to the IDE in an orderly
     /// manner.
-    fn receive_message(&mut self, message: Self::InMessage) {
-        match message {
+    fn receive_messages(&mut self, messages: &mut VecDeque<Self::InMessage>) {
+        match messages.pop_front().unwrap() {
             LspResponse::Type(id, ty) => {
                 let result = languageserver_types::Hover {
                     contents: languageserver_types::HoverContents::Scalar(

--- a/components/lark-query-system/Cargo.toml
+++ b/components/lark-query-system/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.5"
 map = { path = "../map" }
 parking_lot = "0.6.4"
 parser = { path = "../parser" }
-salsa = "0.7"
+salsa = "0.8"
 lark-ty = { path = "../lark-ty" }
 lark-type-check = { path = "../lark-type-check" }
 url = "1.7"

--- a/components/lark-query-system/Cargo.toml
+++ b/components/lark-query-system/Cargo.toml
@@ -13,6 +13,7 @@ hir = { path = "../hir" }
 languageserver-types = "0.51.0"
 lark-entity = { path = "../lark-entity" }
 lark-task-manager = { path = "../lark-task-manager" }
+log = "0.4.5"
 map = { path = "../map" }
 parking_lot = "0.6.4"
 parser = { path = "../parser" }

--- a/components/lark-query-system/src/lib.rs
+++ b/components/lark-query-system/src/lib.rs
@@ -159,6 +159,8 @@ impl Actor for QuerySystem {
     fn shutdown(&mut self) {}
 
     fn receive_message(&mut self, message: Self::InMessage) {
+        log::info!("receive_message(message={:#?})", message);
+
         match message {
             QueryRequest::OpenFile(url, contents) => {
                 // Process sets on the same thread -- this not only gives them priority,
@@ -297,6 +299,8 @@ impl Actor for QuerySystem {
                 });
             }
         }
+
+        log::info!("receive_message: awaiting next message");
     }
 }
 

--- a/components/lark-query-system/src/lib.rs
+++ b/components/lark-query-system/src/lib.rs
@@ -7,6 +7,7 @@ use parking_lot::RwLock;
 use parser::pos::Span;
 use salsa::{Database, ParallelDatabase, Snapshot};
 use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use url::Url;
 
@@ -154,7 +155,9 @@ impl Actor for QuerySystem {
 
     fn shutdown(&mut self) {}
 
-    fn receive_message(&mut self, message: Self::InMessage) {
+    fn receive_messages(&mut self, messages: &mut VecDeque<Self::InMessage>) {
+        let message = messages.pop_front().unwrap();
+
         log::info!("receive_message(message={:#?})", message);
 
         match message {

--- a/components/lark-task-manager/Cargo.toml
+++ b/components/lark-task-manager/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 languageserver-types = "0.51.0"
 lark-mir = { path = "../lark-mir" }
+map = { path = "../map" }
 url = "1.7"

--- a/components/lark-task-manager/src/lib.rs
+++ b/components/lark-task-manager/src/lib.rs
@@ -44,6 +44,7 @@ pub enum LspResponse {
 
 /// Requests from the manager to the query
 /// system
+#[derive(Debug)]
 pub enum QueryRequest {
     /// URI followed by contents
     OpenFile(Url, String),

--- a/components/lark-task-manager/src/lib.rs
+++ b/components/lark-task-manager/src/lib.rs
@@ -53,6 +53,17 @@ pub enum QueryRequest {
     TypeAtPosition(TaskId, Url, Position),
 }
 
+impl QueryRequest {
+    /// True if this query will cause us to mutate the state of the
+    /// program.
+    pub fn is_mutation(&self) -> bool {
+        match self {
+            QueryRequest::OpenFile(..) | QueryRequest::EditFile(..) => true,
+            QueryRequest::TypeAtPosition(..) => false,
+        }
+    }
+}
+
 /// Responses from the query system back to the
 /// manager
 pub enum QueryResponse {

--- a/components/lark-type-check/Cargo.toml
+++ b/components/lark-type-check/Cargo.toml
@@ -18,4 +18,4 @@ lark-unify = { path = "../lark-unify" }
 log = "0.4.5"
 map = { path = "../map" }
 parser = { path = "../parser" }
-salsa = "0.7"
+salsa = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn ide() {
 }
 
 fn main() {
-    Logger::with_env_or_str("error")
+    Logger::with_env_or_str("error,lark_query_system=info")
         .log_to_file()
         .directory("log_files")
         .format(opt_format)


### PR DESCRIPTION
This helps us to always respond promptly.

Also, upgrade to Salsa 0.8.0, which has a cleaned up API that features fewer footguns. =)

