### PR TITLE
patch up holes in type-check, add a way to run w/o the LS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - nightly-2018-10-30
 cache:
 - cargo
 script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
 name = "lark"
 version = "0.1.0"
 dependencies = [
+ "ast 0.1.0",
  "codespan 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ flexi_logger = "0.9.2"
 pretty_env_logger = "0.2"
 salsa = "0.8"
 
+ast = { path = "components/ast" }
 debug = { path = "components/debug" }
 indices = { path = "components/indices" }
 intern = { path = "components/intern" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,11 @@ lark-string = { path = "components/lark-string" }
 lark-task-manager = { path = "components/lark-task-manager" }
 map = { path = "components/map" }
 parser = { path = "components/parser" }
+language-reporting = { git = "https://github.com/wycats/language-reporting.git" }
+termcolor = "1.0.4"
 lark-ty = { path = "components/lark-ty" }
 lark-type-check = { path = "components/lark-type-check" }
 lark-unify = { path = "components/lark-unify" }
 
 [dev-dependencies]
 unindent = "0.1.3"
-language-reporting = { git = "https://github.com/wycats/language-reporting.git" }
-termcolor = "1.0.4"

--- a/components/hir/src/fn_body.rs
+++ b/components/hir/src/fn_body.rs
@@ -118,22 +118,19 @@ where
             .unwrap_or_else(|| self.unit_expression(block.span()))
     }
 
-    fn lower_block_items(&mut self, block_items: &[a::BlockItem]) -> Option<hir::Expression> {
-        if block_items.is_empty() {
-            return None;
-        }
-
-        match &block_items[0] {
-            a::BlockItem::Item(_) => return self.lower_block_items(&block_items[1..]),
+    fn lower_block_items(&mut self, all_block_items: &[a::BlockItem]) -> Option<hir::Expression> {
+        let (first_block_item, remaining_block_items) = all_block_items.split_first()?;
+        match first_block_item {
+            a::BlockItem::Item(_) => return self.lower_block_items(remaining_block_items),
 
             a::BlockItem::Decl(decl) => match decl {
-                a::Declaration::Let(l) => Some(self.lower_let(l, block_items)),
+                a::Declaration::Let(l) => Some(self.lower_let(l, remaining_block_items)),
             },
 
             a::BlockItem::Expr(expr) => {
                 let first = self.lower_expression(expr);
 
-                match self.lower_block_items(&block_items[1..]) {
+                match self.lower_block_items(remaining_block_items) {
                     None => Some(first),
 
                     Some(second) => {

--- a/components/hir/src/fn_body.rs
+++ b/components/hir/src/fn_body.rs
@@ -184,9 +184,11 @@ where
         match expr {
             a::Expression::Block(block) => self.lower_block(block),
 
-            a::Expression::ConstructStruct(_) => unimplemented!("struct construction"),
-
-            a::Expression::Call(_) => unimplemented!("calls"),
+            a::Expression::Literal(..)
+            | a::Expression::Interpolation(..)
+            | a::Expression::Binary(..)
+            | a::Expression::Call(_)
+            | a::Expression::ConstructStruct(_) => self.unimplemented(expr.span()),
 
             a::Expression::Ref(_) => {
                 let place = self.lower_place(expr);
@@ -194,13 +196,12 @@ where
                 let perm = self.add(span, hir::PermData::Default);
                 self.add(span, hir::ExpressionData::Place { perm, place })
             }
-
-            a::Expression::Binary(..) => unimplemented!("binary operators"),
-
-            a::Expression::Interpolation(..) => unimplemented!("interpolation"),
-
-            a::Expression::Literal(..) => unimplemented!("literals"),
         }
+    }
+
+    fn unimplemented(&mut self, span: Span) -> hir::Expression {
+        let error = self.add(span, hir::ErrorData::Unimplemented);
+        self.add(span, hir::ExpressionData::Error { error })
     }
 
     fn lower_place(&mut self, expr: &a::Expression) -> hir::Place {

--- a/components/hir/src/lib.rs
+++ b/components/hir/src/lib.rs
@@ -29,7 +29,7 @@ mod type_conversion;
 salsa::query_group! {
     pub trait HirDatabase: AstDatabase + AsRef<DeclarationTables> {
         /// Get the fn-body for a given def-id.
-        fn fn_body(key: Entity) -> Arc<FnBody> {
+        fn fn_body(key: Entity) -> WithError<Arc<FnBody>> {
             type FnBodyQuery;
             use fn fn_body::fn_body;
         }

--- a/components/hir/src/lib.rs
+++ b/components/hir/src/lib.rs
@@ -523,5 +523,6 @@ indices::index_type! {
 #[derive(Clone, Debug, DebugWith, PartialEq, Eq, Hash)]
 pub enum ErrorData {
     Misc,
+    Unimplemented,
     UnknownIdentifier { text: StringId },
 }

--- a/components/lark-query-system/src/lib.rs
+++ b/components/lark-query-system/src/lib.rs
@@ -11,11 +11,11 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use url::Url;
 
-mod ls_ops;
+pub mod ls_ops;
 use self::ls_ops::{Cancelled, LsDatabase};
 
 #[derive(Default)]
-struct LarkDatabase {
+pub struct LarkDatabase {
     runtime: salsa::Runtime<LarkDatabase>,
     code_map: Arc<RwLock<CodeMap>>,
     file_maps: Arc<RwLock<FxIndexMap<String, Arc<FileMap>>>>,
@@ -23,6 +23,12 @@ struct LarkDatabase {
     item_id_tables: Arc<EntityTables>,
     declaration_tables: Arc<lark_ty::declaration::DeclarationTables>,
     base_inferred_tables: Arc<lark_ty::base_inferred::BaseInferredTables>,
+}
+
+impl LarkDatabase {
+    pub fn code_map(&self) -> &RwLock<CodeMap> {
+        &self.code_map
+    }
 }
 
 impl Database for LarkDatabase {
@@ -52,7 +58,7 @@ impl LsDatabase for LarkDatabase {
 }
 
 salsa::database_storage! {
-    struct LarkDatabaseStorage for LarkDatabase {
+    pub struct LarkDatabaseStorage for LarkDatabase {
         impl ast::AstDatabase {
             fn input_files() for ast::InputFilesQuery;
             fn input_text() for ast::InputTextQuery;

--- a/components/lark-query-system/src/ls_ops.rs
+++ b/components/lark-query-system/src/ls_ops.rs
@@ -115,7 +115,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
                 let _ = self.fn_body(entity).accumulate_errors_into(errors);
-                //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
+                let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
             EntityData::MemberName {
                 kind: MemberKind::Method,
@@ -127,7 +127,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
                 let _ = self.fn_body(entity).accumulate_errors_into(errors);
-                //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
+                let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
         }
 

--- a/components/lark-query-system/src/ls_ops.rs
+++ b/components/lark-query-system/src/ls_ops.rs
@@ -114,6 +114,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                     .accumulate_errors_into(errors);
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
+                let _ = self.fn_body(entity).accumulate_errors_into(errors);
                 //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
             EntityData::MemberName {
@@ -125,6 +126,7 @@ pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
                     .accumulate_errors_into(errors);
                 let _ = self.ty(entity).accumulate_errors_into(errors);
                 let _ = self.signature(entity).accumulate_errors_into(errors);
+                let _ = self.fn_body(entity).accumulate_errors_into(errors);
                 //let _ = self.base_type_check(entity).accumulate_errors_into(errors);
             }
         }

--- a/components/lark-query-system/src/ls_ops.rs
+++ b/components/lark-query-system/src/ls_ops.rs
@@ -16,11 +16,11 @@ use parser::StringId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub(crate) struct Cancelled;
+pub struct Cancelled;
 
-pub(crate) type Cancelable<T> = Result<T, Cancelled>;
+pub type Cancelable<T> = Result<T, Cancelled>;
 
-pub(crate) trait LsDatabase: lark_type_check::TypeCheckDatabase {
+pub trait LsDatabase: lark_type_check::TypeCheckDatabase {
     fn file_maps(&self) -> &RwLock<FxIndexMap<String, Arc<FileMap>>>;
 
     fn check_for_cancellation(&self) -> Cancelable<()> {

--- a/components/lark-type-check/src/hir_typeck.rs
+++ b/components/lark-type-check/src/hir_typeck.rs
@@ -73,11 +73,13 @@ where
             }
 
             hir::ExpressionData::Let {
-                variable: _,
+                variable,
                 initializer: None,
-                body: _,
+                body,
             } => {
-                unimplemented!() // FIXME
+                let ty = self.new_infer_ty();
+                self.results.record_ty(variable, ty);
+                self.check_expression(body)
             }
 
             hir::ExpressionData::Place { perm, place } => {

--- a/components/lark-type-check/src/hir_typeck.rs
+++ b/components/lark-type-check/src/hir_typeck.rs
@@ -179,7 +179,11 @@ where
                             }
                         }
 
-                        BaseKind::Placeholder(_placeholder) => unimplemented!(),
+                        BaseKind::Placeholder(_placeholder) => {
+                            // Cannot presently access fields from generic types.
+                            this.record_error(name);
+                            this.error_type()
+                        }
 
                         BaseKind::Error => this.error_type(),
                     }
@@ -245,7 +249,15 @@ where
                 signature.output
             }
 
-            BaseKind::Placeholder(_placeholder) => unimplemented!(),
+            BaseKind::Placeholder(_placeholder) => {
+                // Cannot presently invoke methods on generic types.
+                let hir = &self.hir.clone();
+                for argument_expr in arguments.iter(hir) {
+                    self.check_expression(argument_expr);
+                }
+                self.record_error(method_name);
+                self.error_type()
+            }
 
             BaseKind::Error => self.error_type(),
         }

--- a/components/lark-type-check/src/hir_typeck.rs
+++ b/components/lark-type-check/src/hir_typeck.rs
@@ -173,7 +173,7 @@ where
                                 }
 
                                 None => {
-                                    this.record_error(place);
+                                    this.record_error(name);
                                     this.error_type()
                                 }
                             }
@@ -234,7 +234,7 @@ where
                 };
                 let signature = self.substitute(expression, &generics, signature_decl);
                 if signature.inputs.len() != arguments.len() {
-                    self.record_error(expression);
+                    self.record_error(method_name);
                 }
                 let hir = &self.hir.clone();
                 for (&expected_ty, argument_expr) in

--- a/components/lark-type-check/src/query_definitions.rs
+++ b/components/lark-type-check/src/query_definitions.rs
@@ -19,7 +19,7 @@ crate fn base_type_check(
     db: &impl TypeCheckDatabase,
     fn_entity: Entity,
 ) -> WithError<Arc<TypeCheckResults<BaseInferred>>> {
-    let fn_body = db.fn_body(fn_entity);
+    let fn_body = db.fn_body(fn_entity).into_value();
     let interners = BaseOnlyTables::default();
     let mut base_type_checker: TypeChecker<'_, _, BaseOnly> = TypeChecker {
         db,

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,76 @@
+use ast::HasParserState;
+use codespan::{CodeMap, ColumnIndex, FileMap, FileName, LineIndex};
+use flexi_logger::{opt_format, Logger};
+use lark_language_server::{lsp_serve, LspResponder};
+use lark_query_system::ls_ops::Cancelled;
+use lark_query_system::ls_ops::LsDatabase;
+use lark_query_system::LarkDatabase;
+use lark_query_system::QuerySystem;
+use lark_task_manager::Actor;
+use parser::pos::Span;
+use salsa::Database;
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::Read;
+use std::sync::Arc;
+use std::{env, io};
+
+pub(crate) fn build(filename: &str) {
+    let mut file = match File::open(filename) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!("failed to open `{}`: {}", filename, err);
+            return;
+        }
+    };
+
+    let mut contents = String::new();
+    match file.read_to_string(&mut contents) {
+        Ok(_bytes_read) => {}
+        Err(err) => {
+            eprintln!("failed to read `{}`: {}", filename, err);
+            return;
+        }
+    }
+
+    let mut db = LarkDatabase::default();
+    let interned_filename = db.intern_string(filename);
+    let interned_contents = db.intern_string(&contents[..]);
+    db.query_mut(ast::InputFilesQuery)
+        .set((), Arc::new(vec![interned_filename]));
+    let file_map = db.code_map().write().add_filemap(
+        FileName::Virtual(Cow::Owned(filename.to_string())),
+        contents.to_string(),
+    );
+    let file_span = file_map.span();
+    let start_offset = file_map.span().start().to_usize() as u32;
+    db.file_maps()
+        .write()
+        .insert(filename.to_string(), file_map);
+    db.query_mut(ast::InputTextQuery).set(
+        interned_filename,
+        Some(ast::InputText {
+            text: interned_contents,
+            start_offset,
+            span: Span::from(file_span),
+        }),
+    );
+    match db.errors_for_project() {
+        Ok(errors) => {
+            for (filename, ranges) in errors {
+                for range in ranges {
+                    eprintln!(
+                        "{}:{}:{}:{}:{}: error",
+                        filename,
+                        range.start.line,
+                        range.start.character,
+                        range.end.line,
+                        range.end.character,
+                    );
+                }
+            }
+        }
+
+        Err(Cancelled) => unreachable!("cancellation?"),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use lark_query_system::QuerySystem;
 use lark_task_manager::Actor;
 use std::{env, io};
 
-fn build(_filename: &str) {}
+mod build;
 
 fn run(_filename: &str) {}
 
@@ -51,7 +51,7 @@ fn main() {
     log::error!("Lark: executing");
 
     match (args.next(), args.next(), args.next()) {
-        (_, Some(ref cmd), Some(ref x)) if cmd == "build" => build(x),
+        (_, Some(ref cmd), Some(ref x)) if cmd == "build" => build::build(x),
         (_, Some(ref cmd), Some(ref x)) if cmd == "run" => run(x),
         (_, Some(ref cmd), None) if cmd == "repl" => repl(),
         (_, Some(ref cmd), None) if cmd == "ide" => ide(),


### PR DESCRIPTION
Anecdotally, seems to work as I edit things -- of course the only stuff that HIR lowering supports is basically variable names.

I added `build foo` as a way to debug problems outside of the LS:

```bash
> cargo run -- build samples/challenge1.lark
    Finished dev [optimized + debuginfo] target(s) in 0.16s
     Running `target/debug/lark build samples/challenge1.lark`
Lark: executing
error: something is wrong here =)
- <samples/challenge1.lark>:6:18
6 | def new(msg: own String, level: String) -> Diagnostic {
  |                  ^^^^^^

error: something is wrong here =)
- <samples/challenge1.lark>:6:33
6 | def new(msg: own String, level: String) -> Diagnostic {
  |                                 ^^^^^^
```