### PR TITLE
introduce a `Seq` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "lark-mir 0.1.0",
  "lark-parser 0.1.0",
  "lark-query-system 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "lark-task-manager 0.1.0",
  "lark-test 0.1.0",
@@ -512,6 +513,13 @@ dependencies = [
  "parser 0.1.0",
  "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lark-seq"
+version = "0.1.0"
+dependencies = [
+ "debug 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "lark-debug-derive 0.1.0",
  "lark-entity 0.1.0",
  "lark-error 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -422,6 +423,7 @@ version = "0.1.0"
 dependencies = [
  "debug 0.1.0",
  "lark-debug-derive 0.1.0",
+ "lark-seq 0.1.0",
  "parser 0.1.0",
 ]
 
@@ -443,6 +445,7 @@ dependencies = [
  "lark-debug-derive 0.1.0",
  "lark-entity 0.1.0",
  "lark-error 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "lark-ty 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -479,6 +482,7 @@ dependencies = [
  "lark-debug-derive 0.1.0",
  "lark-entity 0.1.0",
  "lark-error 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "map 0.1.0",
@@ -556,6 +560,7 @@ dependencies = [
  "lark-hir 0.1.0",
  "lark-parser 0.1.0",
  "lark-query-system 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "parser 0.1.0",
  "salsa 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,6 +578,7 @@ dependencies = [
  "lark-debug-derive 0.1.0",
  "lark-entity 0.1.0",
  "lark-error 0.1.0",
+ "lark-seq 0.1.0",
  "lark-string 0.1.0",
  "lark-unify 0.1.0",
  "map 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ lark-test = { path = "components/lark-test" }
 lark-entity = { path = "components/lark-entity" }
 lark-parser = { path = "components/lark-parser" }
 env_logger = "0.5.13"
+lark-seq = { path = "components/lark-seq" }

--- a/components/ast/Cargo.toml
+++ b/components/ast/Cargo.toml
@@ -15,6 +15,7 @@ lark-debug-derive = { path = "../lark-debug-derive" }
 lark-error = { path = "../lark-error" }
 lark-entity = { path = "../lark-entity" }
 lark-string = { path = "../lark-string" }
+lark-seq = { path = "../lark-seq" }
 indices = { path = "../indices" }
 intern = { path = "../intern" }
 parser = { path = "../parser" }

--- a/components/ast/src/lib.rs
+++ b/components/ast/src/lib.rs
@@ -9,6 +9,7 @@
 use lark_entity::Entity;
 use lark_entity::EntityTables;
 use lark_error::{ErrorReported, WithError};
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
 pub use parser::ast;
 use parser::pos::Span;
@@ -28,7 +29,7 @@ salsa::query_group! {
             use fn query_definitions::ast_of_file;
         }
 
-        fn items_in_file(path: GlobalIdentifier) -> Arc<Vec<Entity>> {
+        fn items_in_file(path: GlobalIdentifier) -> Seq<Entity> {
             type ItemsInFileQuery;
             use fn query_definitions::items_in_file;
         }

--- a/components/ast/src/query_definitions.rs
+++ b/components/ast/src/query_definitions.rs
@@ -8,6 +8,7 @@ use lark_entity::ItemKind;
 use lark_entity::MemberKind;
 use lark_error::or_return_sentinel;
 use lark_error::{Diagnostic, ErrorReported, WithError};
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
 use parser::ast;
 use parser::pos::{HasSpan, Span};
@@ -32,7 +33,7 @@ crate fn ast_of_file(
     }
 }
 
-crate fn items_in_file(db: &impl AstDatabase, input_file: GlobalIdentifier) -> Arc<Vec<Entity>> {
+crate fn items_in_file(db: &impl AstDatabase, input_file: GlobalIdentifier) -> Seq<Entity> {
     log::debug!("items_in_file(input_file={})", input_file.debug_with(db));
 
     let ast_of_file = or_return_sentinel!(db, db.ast_of_file(input_file).into_value());
@@ -46,7 +47,7 @@ crate fn items_in_file(db: &impl AstDatabase, input_file: GlobalIdentifier) -> A
         input_file_id.debug_with(db)
     );
 
-    let items: Vec<_> = ast_of_file
+    ast_of_file
         .items
         .iter()
         .map(|item| {
@@ -61,9 +62,7 @@ crate fn items_in_file(db: &impl AstDatabase, input_file: GlobalIdentifier) -> A
             }
             .intern(db)
         })
-        .collect();
-
-    Arc::new(items)
+        .collect()
 }
 
 crate fn ast_of_item(

--- a/components/lark-error/Cargo.toml
+++ b/components/lark-error/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 debug = { path = "../debug" }
 lark-debug-derive = { path = "../lark-debug-derive" }
+lark-seq = { path = "../lark-seq" }
 parser = { path = "../parser" }

--- a/components/lark-error/src/lib.rs
+++ b/components/lark-error/src/lib.rs
@@ -29,6 +29,8 @@
 #![feature(decl_macro)]
 
 use lark_debug_derive::DebugWith;
+use lark_seq::seq;
+use lark_seq::Seq;
 use parser::pos::Span;
 use std::sync::Arc;
 
@@ -189,6 +191,15 @@ where
 {
     fn error_sentinel(cx: Cx, report: ErrorReported) -> Self {
         vec![T::error_sentinel(cx, report)]
+    }
+}
+
+impl<T, Cx> ErrorSentinel<Cx> for Seq<T>
+where
+    T: ErrorSentinel<Cx>,
+{
+    fn error_sentinel(cx: Cx, report: ErrorReported) -> Self {
+        seq![T::error_sentinel(cx, report)]
     }
 }
 

--- a/components/lark-hir/Cargo.toml
+++ b/components/lark-hir/Cargo.toml
@@ -17,6 +17,7 @@ lark-debug-derive = { path = "../lark-debug-derive" }
 lark-entity = { path = "../lark-entity" }
 lark-error = { path = "../lark-error" }
 lark-string = { path = "../lark-string" }
+lark-seq = { path = "../lark-seq" }
 map = { path = "../map" }
 parser = { path = "../parser" }
 lark-ty = { path = "../lark-ty" }

--- a/components/lark-hir/src/lib.rs
+++ b/components/lark-hir/src/lib.rs
@@ -15,6 +15,7 @@ use lark_entity::Entity;
 use lark_entity::MemberKind;
 use lark_error::ErrorReported;
 use lark_error::WithError;
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
 use lark_ty as ty;
 use lark_ty::declaration::{Declaration, DeclarationTables};
@@ -35,7 +36,7 @@ salsa::query_group! {
         }
 
         /// Get the list of member names and their def-ids for a given struct.
-        fn members(key: Entity) -> Result<Arc<Vec<Member>>, ErrorReported> {
+        fn members(key: Entity) -> Result<Seq<Member>, ErrorReported> {
             type MembersQuery;
             use fn query_definitions::members;
         }
@@ -46,7 +47,7 @@ salsa::query_group! {
             use fn query_definitions::member_entity;
         }
 
-        fn subentities(entity: Entity) -> Arc<Vec<Entity>> {
+        fn subentities(entity: Entity) -> Seq<Entity> {
             type SubentitiesQuery;
             use fn query_definitions::subentities;
         }

--- a/components/lark-hir/src/query_definitions.rs
+++ b/components/lark-hir/src/query_definitions.rs
@@ -9,30 +9,29 @@ use lark_entity::ItemKind;
 use lark_entity::MemberKind;
 use lark_error::ErrorReported;
 use lark_error::ErrorSentinel;
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
-use std::sync::Arc;
 
-crate fn members(db: &impl HirDatabase, owner: Entity) -> Result<Arc<Vec<Member>>, ErrorReported> {
+crate fn members(db: &impl HirDatabase, owner: Entity) -> Result<Seq<Member>, ErrorReported> {
     match &*db.ast_of_item(owner)? {
-        a::Item::Struct(s) => Ok(Arc::new(
-            s.fields
-                .iter()
-                .map(|f| {
-                    let field_entity = EntityData::MemberName {
-                        base: owner,
-                        kind: MemberKind::Field,
-                        id: *f.name,
-                    }
-                    .intern(db);
+        a::Item::Struct(s) => Ok(s
+            .fields
+            .iter()
+            .map(|f| {
+                let field_entity = EntityData::MemberName {
+                    base: owner,
+                    kind: MemberKind::Field,
+                    id: *f.name,
+                }
+                .intern(db);
 
-                    Member {
-                        name: *f.name,
-                        kind: MemberKind::Field,
-                        entity: field_entity,
-                    }
-                })
-                .collect(),
-        )),
+                Member {
+                    name: *f.name,
+                    kind: MemberKind::Field,
+                    entity: field_entity,
+                }
+            })
+            .collect()),
 
         a::Item::Def(_) => panic!("asked for members of a function"),
     }
@@ -60,7 +59,7 @@ crate fn member_entity(
     }
 }
 
-crate fn subentities(db: &impl HirDatabase, root: Entity) -> Arc<Vec<Entity>> {
+crate fn subentities(db: &impl HirDatabase, root: Entity) -> Seq<Entity> {
     let mut entities = vec![root];
 
     // Go over each thing added to entities and add any nested
@@ -93,5 +92,5 @@ crate fn subentities(db: &impl HirDatabase, root: Entity) -> Arc<Vec<Entity>> {
         }
     }
 
-    Arc::new(entities)
+    Seq::from(entities)
 }

--- a/components/lark-hir/src/type_conversion.rs
+++ b/components/lark-hir/src/type_conversion.rs
@@ -11,6 +11,7 @@ use lark_error::or_return_sentinel;
 use lark_error::ErrorReported;
 use lark_error::ErrorSentinel;
 use lark_error::WithError;
+use lark_seq::Seq;
 use lark_ty::declaration::Declaration;
 use lark_ty::BaseData;
 use lark_ty::BaseKind;
@@ -142,7 +143,7 @@ crate fn signature(
         a::Item::Struct(_) => panic!("asked for signature of a struct"),
 
         a::Item::Def(d) => {
-            let inputs: Vec<_> = d
+            let inputs: Seq<_> = d
                 .parameters
                 .iter()
                 .map(|p| {
@@ -158,10 +159,7 @@ crate fn signature(
             };
 
             WithError {
-                value: Ok(Signature {
-                    inputs: Arc::new(inputs),
-                    output,
-                }),
+                value: Ok(Signature { inputs, output }),
                 errors,
             }
         }

--- a/components/lark-parser/Cargo.toml
+++ b/components/lark-parser/Cargo.toml
@@ -14,6 +14,7 @@ lark-debug-derive = { path = "../lark-debug-derive" }
 lark-error = { path = "../lark-error" }
 lark-entity = { path = "../lark-entity" }
 lark-string = { path = "../lark-string" }
+lark-seq = { path = "../lark-seq" }
 log = "0.4.5"
 map = { path = "../map" }
 parser = { path = "../parser" }

--- a/components/lark-parser/src/lib.rs
+++ b/components/lark-parser/src/lib.rs
@@ -15,10 +15,10 @@ use lark_entity::Entity;
 use lark_entity::EntityTables;
 use lark_error::Diagnostic;
 use lark_error::WithError;
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
 use lark_string::global::GlobalIdentifierTables;
 use lark_string::text::Text;
-use std::sync::Arc;
 
 pub mod current_file;
 mod lexer;
@@ -33,7 +33,7 @@ salsa::query_group! {
         + AsRef<EntityTables>
         + salsa::Database
     {
-        fn file_names() -> Arc<Vec<FileName>> {
+        fn file_names() -> Seq<FileName> {
             type FileNamesQuery;
             storage input;
         }
@@ -43,7 +43,7 @@ salsa::query_group! {
             storage input;
         }
 
-        fn child_parsed_entities(entity: Entity) -> WithError<Arc<Vec<ParsedEntity>>> {
+        fn child_parsed_entities(entity: Entity) -> WithError<Seq<ParsedEntity>> {
             type ChildParsedEntitiesQuery;
             use fn query_definitions::child_parsed_entities;
         }
@@ -53,7 +53,7 @@ salsa::query_group! {
             use fn query_definitions::parsed_entity;
         }
 
-        fn child_entities(entity: Entity) -> Arc<Vec<Entity>> {
+        fn child_entities(entity: Entity) -> Seq<Entity> {
             type ChildEntitiesQuery;
             use fn query_definitions::child_entities;
         }

--- a/components/lark-parser/src/macros/struct_declaration.rs
+++ b/components/lark-parser/src/macros/struct_declaration.rs
@@ -19,8 +19,8 @@ use lark_entity::ItemKind;
 use lark_entity::MemberKind;
 use lark_error::ErrorReported;
 use lark_error::WithError;
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
-use std::sync::Arc;
 
 /// ```ignore
 /// struct <id> {
@@ -49,7 +49,7 @@ impl EntityMacroDefinition for StructDeclaration {
         log::trace!("StructDeclaration::parse: parsing fields");
         let fields = parser
             .expect(Delimited(Curlies, CommaList(Field)))
-            .unwrap_or_else(|ErrorReported(_)| vec![]);
+            .unwrap_or_else(|ErrorReported(_)| Seq::default());
 
         log::trace!("StructDeclaration::parse: done");
         let entity = EntityData::ItemName {
@@ -61,7 +61,6 @@ impl EntityMacroDefinition for StructDeclaration {
 
         let full_span = macro_name.span.extended_until_end_of(parser.last_span());
         let characteristic_span = struct_name.span;
-        let fields = Arc::new(fields);
 
         Ok(ParsedEntity::new(
             entity,
@@ -73,7 +72,7 @@ impl EntityMacroDefinition for StructDeclaration {
 }
 
 struct ParsedStructDeclaration {
-    fields: Arc<Vec<Spanned<ParsedField>>>,
+    fields: Seq<Spanned<ParsedField>>,
 }
 
 impl LazyParsedEntity for ParsedStructDeclaration {

--- a/components/lark-parser/src/parser.rs
+++ b/components/lark-parser/src/parser.rs
@@ -14,6 +14,7 @@ use lark_entity::EntityTables;
 use lark_error::Diagnostic;
 use lark_error::ErrorReported;
 use lark_error::WithError;
+use lark_seq::Seq;
 use lark_string::global::GlobalIdentifier;
 use lark_string::global::GlobalIdentifierTables;
 use lark_string::text::Text;
@@ -59,10 +60,7 @@ impl Parser<'me> {
 
     /// Parse all the entities we can and return a vector
     /// (accumulating errors as we go).
-    crate fn parse_all_entities(
-        mut self,
-        parent_entity: Entity,
-    ) -> WithError<Arc<Vec<ParsedEntity>>> {
+    crate fn parse_all_entities(mut self, parent_entity: Entity) -> WithError<Seq<ParsedEntity>> {
         let mut entities = vec![];
         while let Some(entity) = self.eat(EntitySyntax::new(parent_entity)) {
             match entity {
@@ -72,7 +70,7 @@ impl Parser<'me> {
         }
 
         WithError {
-            value: Arc::new(entities),
+            value: Seq::from(entities),
             errors: self.errors,
         }
     }

--- a/components/lark-parser/src/query_definitions.rs
+++ b/components/lark-parser/src/query_definitions.rs
@@ -9,12 +9,12 @@ use intern::Untern;
 use lark_entity::Entity;
 use lark_entity::EntityData;
 use lark_error::WithError;
-use std::sync::Arc;
+use lark_seq::Seq;
 
 crate fn child_parsed_entities(
     db: &impl ParserDatabase,
     entity: Entity,
-) -> WithError<Arc<Vec<ParsedEntity>>> {
+) -> WithError<Seq<ParsedEntity>> {
     log::debug!("child_parsed_entities({})", entity.debug_with(db));
 
     match entity.untern(db) {
@@ -31,10 +31,10 @@ crate fn child_parsed_entities(
             .parsed_entity(entity)
             .thunk
             .parse_children(entity, db)
-            .map(Arc::new),
+            .map(Seq::from),
 
         EntityData::Error { .. } | EntityData::MemberName { .. } | EntityData::LangItem(_) => {
-            WithError::ok(Arc::new(vec![]))
+            WithError::ok(Seq::default())
         }
     }
 }
@@ -68,12 +68,10 @@ crate fn parsed_entity(db: &impl ParserDatabase, entity: Entity) -> ParsedEntity
     }
 }
 
-crate fn child_entities(db: &impl ParserDatabase, entity: Entity) -> Arc<Vec<Entity>> {
-    Arc::new(
-        db.child_parsed_entities(entity)
-            .into_value()
-            .iter()
-            .map(|parsed_entity| parsed_entity.entity)
-            .collect(),
-    )
+crate fn child_entities(db: &impl ParserDatabase, entity: Entity) -> Seq<Entity> {
+    db.child_parsed_entities(entity)
+        .into_value()
+        .iter()
+        .map(|parsed_entity| parsed_entity.entity)
+        .collect()
 }

--- a/components/lark-parser/src/syntax/list.rs
+++ b/components/lark-parser/src/syntax/list.rs
@@ -3,6 +3,7 @@ use crate::syntax::sigil::Comma;
 use crate::syntax::Syntax;
 use lark_debug_derive::DebugWith;
 use lark_error::ErrorReported;
+use lark_seq::Seq;
 
 #[derive(DebugWith)]
 pub struct CommaList<T>(pub T);
@@ -17,13 +18,13 @@ impl<T> Syntax for CommaList<T>
 where
     T: Syntax,
 {
-    type Data = Vec<T::Data>;
+    type Data = Seq<T::Data>;
 
     fn test(&self, parser: &Parser<'_>) -> bool {
         SeparatedList(self.element(), Comma).test(parser)
     }
 
-    fn parse(&self, parser: &mut Parser<'_>) -> Result<Vec<T::Data>, ErrorReported> {
+    fn parse(&self, parser: &mut Parser<'_>) -> Result<Seq<T::Data>, ErrorReported> {
         SeparatedList(self.element(), Comma).parse(parser)
     }
 }
@@ -64,13 +65,13 @@ where
     T: Syntax,
     S: Syntax,
 {
-    type Data = Vec<T::Data>;
+    type Data = Seq<T::Data>;
 
     fn test(&self, _parser: &Parser<'_>) -> bool {
         true // we never produce an error
     }
 
-    fn parse(&self, parser: &mut Parser<'_>) -> Result<Vec<T::Data>, ErrorReported> {
+    fn parse(&self, parser: &mut Parser<'_>) -> Result<Seq<T::Data>, ErrorReported> {
         let SeparatedList(element, delimiter) = self;
 
         let mut result = vec![];
@@ -92,6 +93,6 @@ where
             }
         }
 
-        Ok(result)
+        Ok(Seq::from(result))
     }
 }

--- a/components/lark-seq/Cargo.toml
+++ b/components/lark-seq/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lark-seq"
+version = "0.1.0"
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+edition = "2018"
+
+[dependencies]
+debug = { path = "../debug" }

--- a/components/lark-seq/src/lib.rs
+++ b/components/lark-seq/src/lib.rs
@@ -1,5 +1,7 @@
 use debug::DebugWith;
 use std::fmt::Debug;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::iter::once;
 use std::iter::FromIterator;
 use std::ops::Deref;
@@ -195,4 +197,21 @@ impl<T> FromIterator<T> for Seq<T> {
         let vec: Vec<T> = iter.into_iter().collect();
         Seq::from(vec)
     }
+}
+
+impl<T: Hash> Hash for Seq<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        <[T] as Hash>::hash(self, state)
+    }
+}
+
+#[macro_export]
+macro_rules! seq {
+    () => {
+        $crate::Seq::default()
+    };
+
+    ($($v:expr),* $(,)*) => {
+        $crate::Seq::from(vec![$($v),*])
+    };
 }

--- a/components/lark-seq/src/lib.rs
+++ b/components/lark-seq/src/lib.rs
@@ -1,0 +1,198 @@
+use debug::DebugWith;
+use std::fmt::Debug;
+use std::iter::once;
+use std::iter::FromIterator;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::ops::Range;
+use std::sync::Arc;
+
+mod test;
+
+pub struct Seq<T> {
+    vec: Option<Arc<Vec<T>>>,
+    start: usize,
+    end: usize,
+}
+
+impl<T> Seq<T> {
+    /// Modifies this restrict to a subset of its current range.
+    pub fn select(&mut self, range: Range<usize>) {
+        let len = range.end - range.start;
+        let new_start = self.start + range.start;
+        let new_end = new_start + len;
+        assert!(new_end <= self.end);
+
+        self.start = new_start;
+        self.end = new_end;
+    }
+
+    /// Extract a new `Text` that is a subset of an old `Text`
+    /// -- `text.extract(1..3)` is similar to `&foo[1..3]` except that
+    /// it gives back an owned value instead of a borrowed value.
+    pub fn extract(&self, range: Range<usize>) -> Self {
+        let mut result = self.clone();
+        result.select(range);
+        result
+    }
+
+    /// Extend this `Seq`. Note that seqs from which this was cloned
+    /// are not affected.
+    pub fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+        T: Clone,
+    {
+        let mut iter = iter.into_iter();
+
+        // Peel off the first item; if there is none, then just do nothing.
+        if let Some(first) = iter.next() {
+            // Create an iterator with that first item plus the rest
+            let iter = once(first).chain(iter);
+
+            // Try to extend in place:
+            if let Some(vec) = &mut self.vec {
+                if self.start == 0 && self.end == vec.len() {
+                    Arc::make_mut(vec).extend(iter);
+                    self.end = vec.len();
+                    return;
+                }
+            }
+
+            // If not, construct a new vector.
+            let v: Vec<T> = self.iter().cloned().chain(iter).collect();
+            let len = v.len();
+            self.vec = Some(Arc::new(v));
+            self.start = 0;
+            self.end = len;
+        }
+    }
+}
+
+impl<T> Clone for Seq<T> {
+    fn clone(&self) -> Self {
+        Self {
+            vec: self.vec.clone(),
+            start: self.start,
+            end: self.end,
+        }
+    }
+}
+
+impl<T> Default for Seq<T> {
+    fn default() -> Self {
+        Self {
+            vec: None,
+            start: 0,
+            end: 0,
+        }
+    }
+}
+
+impl<T> From<Arc<Vec<T>>> for Seq<T> {
+    fn from(vec: Arc<Vec<T>>) -> Self {
+        if vec.is_empty() {
+            Seq::default()
+        } else {
+            let len = vec.len();
+            Seq {
+                vec: Some(vec),
+                start: 0,
+                end: len,
+            }
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for Seq<T> {
+    fn from(vec: Vec<T>) -> Self {
+        if vec.is_empty() {
+            Seq::default()
+        } else {
+            Self::from(Arc::new(vec))
+        }
+    }
+}
+
+impl<T: Clone> From<&[T]> for Seq<T> {
+    fn from(text: &[T]) -> Self {
+        let vec: Vec<T> = text.iter().cloned().collect();
+        Self::from(vec)
+    }
+}
+
+impl<T> Deref for Seq<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        match &self.vec {
+            None => &[],
+            Some(vec) => &vec[self.start..self.end],
+        }
+    }
+}
+
+impl<T: Clone> DerefMut for Seq<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        match &mut self.vec {
+            None => &mut [],
+            Some(vec) => &mut Arc::make_mut(vec)[self.start..self.end],
+        }
+    }
+}
+
+impl<T: Debug> std::fmt::Debug for Seq<T> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <[T] as std::fmt::Debug>::fmt(self, fmt)
+    }
+}
+
+impl<T: DebugWith> DebugWith for Seq<T> {
+    fn fmt_with<Cx: ?Sized>(&self, cx: &Cx, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <[T] as DebugWith>::fmt_with(self, cx, fmt)
+    }
+}
+
+impl<T: PartialEq> PartialEq<Seq<T>> for Seq<T> {
+    fn eq(&self, other: &Seq<T>) -> bool {
+        let this: &[T] = self;
+        let other: &[T] = other;
+        this == other
+    }
+}
+
+impl<T: Eq> Eq for Seq<T> {}
+
+impl<T: PartialEq> PartialEq<[T]> for Seq<T> {
+    fn eq(&self, other: &[T]) -> bool {
+        let this: &[T] = self;
+        this == other
+    }
+}
+
+impl<T: PartialEq> PartialEq<Vec<T>> for Seq<T> {
+    fn eq(&self, other: &Vec<T>) -> bool {
+        let this: &[T] = self;
+        let other: &[T] = other;
+        this == other
+    }
+}
+
+impl<A: ?Sized, T: PartialEq> PartialEq<&A> for Seq<T>
+where
+    Seq<T>: PartialEq<A>,
+{
+    fn eq(&self, other: &&A) -> bool {
+        self == *other
+    }
+}
+
+impl<T> FromIterator<T> for Seq<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let vec: Vec<T> = iter.into_iter().collect();
+        Seq::from(vec)
+    }
+}

--- a/components/lark-seq/src/test.rs
+++ b/components/lark-seq/src/test.rs
@@ -1,0 +1,78 @@
+#![cfg(test)]
+
+use crate::Seq;
+
+#[test]
+fn ne() {
+    let x: Seq<u32> = (0..10).collect();
+    let y: Seq<u32> = (0..20).collect();
+    assert!(x != y);
+}
+
+#[test]
+fn eq_same() {
+    let x: Seq<u32> = (0..10).collect();
+    let y: Seq<u32> = (0..10).collect();
+    assert!(x == y);
+}
+
+#[test]
+fn eq_select() {
+    let mut x: Seq<u32> = (0..20).collect();
+    x.select(10..20);
+
+    let y: Seq<u32> = (10..20).collect();
+
+    assert!(x == y);
+}
+
+#[test]
+fn extend_empty() {
+    let mut x: Seq<u32> = Seq::default();
+    x.extend(0..5);
+    assert_eq!(&[0, 1, 2, 3, 4], &x[..]);
+}
+
+#[test]
+fn extend_non_empty() {
+    let mut x: Seq<u32> = Seq::default();
+    x.extend(0..5);
+    x.extend(6..10);
+    assert_eq!(&[0, 1, 2, 3, 4, 6, 7, 8, 9], &x[..]);
+}
+
+#[test]
+fn extend_select() {
+    let mut x: Seq<u32> = Seq::default();
+
+    x.extend(0..5);
+    x.select(3..5);
+    assert_eq!(&[3, 4], &x[..]);
+
+    x.extend(6..10);
+    assert_eq!(&[3, 4, 6, 7, 8, 9], &x[..]);
+}
+
+#[test]
+fn extend_extracted() {
+    let mut x: Seq<u32> = Seq::default();
+    x.extend(0..5);
+
+    let mut y = x.extract(3..5);
+    y.extend(6..10);
+
+    assert_eq!(&[0, 1, 2, 3, 4], &x[..]);
+    assert_eq!(&[3, 4, 6, 7, 8, 9], &y[..]);
+}
+
+#[test]
+fn extend_cloned() {
+    let mut x: Seq<u32> = Seq::default();
+    x.extend(0..5);
+
+    let mut y = x.clone();
+    y.extend(6..10);
+
+    assert_eq!(&[0, 1, 2, 3, 4], &x[..]);
+    assert_eq!(&[0, 1, 2, 3, 4, 6, 7, 8, 9], &y[..]);
+}

--- a/components/lark-string/src/text.rs
+++ b/components/lark-string/src/text.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 /// an `&Text` into a `&str` for interoperability.
 ///
 /// Used to represent the value of an input file.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Hash)]
 pub struct Text {
     text: Arc<String>,
     start: usize,
@@ -106,6 +106,16 @@ impl DebugWith for Text {
         <str as DebugWith>::fmt_with(self, cx, fmt)
     }
 }
+
+impl PartialEq<Text> for Text {
+    fn eq(&self, other: &Text) -> bool {
+        let this: &str = self;
+        let other: &str = other;
+        this == other
+    }
+}
+
+impl Eq for Text {}
 
 impl PartialEq<str> for Text {
     fn eq(&self, other: &str) -> bool {

--- a/components/lark-test/Cargo.toml
+++ b/components/lark-test/Cargo.toml
@@ -12,8 +12,9 @@ env_logger = "0.5.13"
 lark-error = { path = "../lark-error" }
 lark-hir = { path = "../lark-hir" }
 lark-query-system = { path = "../lark-query-system" }
-lark-string = { path = "../lark-string" }
 lark-parser = { path = "../lark-parser" }
+lark-string = { path = "../lark-string" }
+lark-seq = { path = "../lark-seq" }
 intern = { path = "../intern" }
 parser = { path = "../parser" }
 salsa = "0.8.0"

--- a/components/lark-test/src/lib.rs
+++ b/components/lark-test/src/lib.rs
@@ -6,11 +6,11 @@ use lark_query_system::ls_ops::Cancelled;
 use lark_query_system::ls_ops::LsDatabase;
 use lark_query_system::ls_ops::RangedDiagnostic;
 use lark_query_system::LarkDatabase;
+use lark_seq::seq;
 use lark_string::text::Text;
 use parser::HasParserState;
 use parser::HasReaderState;
 use salsa::Database;
-use std::sync::Arc;
 
 pub trait ErrorSpec {
     fn check_errors(&self, errors: &[RangedDiagnostic]);
@@ -102,7 +102,7 @@ pub fn lark_parser_db(text: impl AsRef<str>) -> (FileName, LarkDatabase) {
     };
     let text = Text::from(text);
     db.query_mut(lark_parser::FileNamesQuery)
-        .set((), Arc::new(vec![path1]));
+        .set((), seq![path1]);
     db.query_mut(lark_parser::FileTextQuery).set(path1, text);
 
     (path1, db)

--- a/components/lark-ty/Cargo.toml
+++ b/components/lark-ty/Cargo.toml
@@ -17,5 +17,6 @@ lark-debug-derive = { path = "../lark-debug-derive" }
 lark-error = { path = "../lark-error" }
 lark-entity = { path = "../lark-entity" }
 lark-string = { path = "../lark-string" }
+lark-seq = { path = "../lark-seq" }
 parser = { path = "../parser" }
 lark-unify = { path = "../lark-unify" }

--- a/components/lark-ty/src/map_family.rs
+++ b/components/lark-ty/src/map_family.rs
@@ -7,6 +7,7 @@ use crate::Signature;
 use crate::Ty;
 use crate::TypeFamily;
 use lark_entity::Entity;
+use lark_seq::Seq;
 use map::FxIndexMap;
 use map::FxIndexSet;
 use std::collections::BTreeMap;
@@ -75,6 +76,19 @@ where
     V: Map<S, T>,
 {
     type Output = Vec<V::Output>;
+
+    fn map(&self, mapper: &mut impl FamilyMapper<S, T>) -> Self::Output {
+        self.iter().map(|e| e.map(mapper)).collect()
+    }
+}
+
+impl<S, T, V> Map<S, T> for Seq<V>
+where
+    S: TypeFamily,
+    T: TypeFamily,
+    V: Map<S, T>,
+{
+    type Output = Seq<V::Output>;
 
     fn map(&self, mapper: &mut impl FamilyMapper<S, T>) -> Self::Output {
         self.iter().map(|e| e.map(mapper)).collect()


### PR DESCRIPTION
`Arc<Vec<T>>` is annoying.

`Seq<T>` is more convenient and nice.

We could move to a full blown persistent collection at some point but I suspect we won't need it really -- mostly we have vectors that we build up in some way and then clone a lot. 

This type supports also extracting subviews in case we ever want that (they share the same backing storage for now).