### PR TITLE
Add a repl to Lark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "lark-build 0.1.0",
  "lark-debug-derive 0.1.0",
  "lark-entity 0.1.0",
+ "lark-error 0.1.0",
  "lark-eval 0.1.0",
  "lark-hir 0.1.0",
  "lark-language-server 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ intern = { path = "components/intern" }
 lark-build = { path = "components/lark-build" }
 lark-debug-derive = { path = "components/lark-debug-derive" }
 lark-entity = { path = "components/lark-entity" }
+lark-error = { path = "components/lark-error" }
 lark-eval = { path = "components/lark-eval" }
 lark-hir = { path = "components/lark-hir" }
 lark-language-server = { path = "components/lark-language-server" }
@@ -52,13 +53,13 @@ lark-mir = { path = "components/lark-mir" }
 lark-query-system = { path = "components/lark-query-system" }
 lark-string = { path = "components/lark-string" } 
 lark-task-manager = { path = "components/lark-task-manager" }
+lark-ty = { path = "components/lark-ty" }
+lark-type-check = { path = "components/lark-type-check" }
+lark-unify = { path = "components/lark-unify" }
 map = { path = "components/map" }
 parser = { path = "components/parser" }
 language-reporting = "0.2.0"
 termcolor = "1.0.4"
-lark-ty = { path = "components/lark-ty" }
-lark-type-check = { path = "components/lark-type-check" }
-lark-unify = { path = "components/lark-unify" }
 
 [dev-dependencies]
 unindent = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,8 @@ use lark_task_manager::Actor;
 use std::{env, io};
 
 mod build;
+mod repl;
 mod run;
-
-fn repl() {}
 
 fn ide() {
     let query_system = QuerySystem::new();
@@ -52,7 +51,7 @@ fn main() {
         }
         (_, Some(ref cmd), Some(ref x), None) if cmd == "build" => build::build(x, None),
         (_, Some(ref cmd), Some(ref x), None) if cmd == "run" => run::run(x),
-        (_, Some(ref cmd), None, None) if cmd == "repl" => repl(),
+        (_, Some(ref cmd), None, None) if cmd == "repl" => repl::repl(),
         (_, Some(ref cmd), None, None) if cmd == "ide" => ide(),
         _ => {
             println!("Usage:");

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -44,6 +44,7 @@ pub fn repl() {
     let mut variables: HashMap<Variable, Vec<Value>> = HashMap::new();
     let mut num_to_skip = 0;
 
+    println!("Lark repl (:? - command help)");
     loop {
         let mut input = String::new();
 
@@ -64,6 +65,13 @@ pub fn repl() {
         }
         if input == ":v" {
             println!("{:#?}", variables);
+            continue;
+        }
+        if input == ":?" {
+            println!("Commands available:");
+            println!("  :q - quit");
+            println!("  :p - view currently accepted source lines");
+            println!("  :v - view variables");
             continue;
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,143 @@
+use ast::AstDatabase;
+use intern::{Intern, Untern};
+use lark_entity::{EntityData, ItemKind};
+use lark_eval::Value;
+use lark_mir::{FnBytecode, MirDatabase, StatementKind, Variable};
+use lark_query_system::ls_ops::LsDatabase;
+use lark_query_system::LarkDatabase;
+use parser::{HasParserState, HasReaderState, ReaderDatabase};
+use std::collections::HashMap;
+use std::io::{stdin, stdout, Write};
+
+const REPL_FILENAME: &str = "__REPL__.lark";
+
+pub fn get_bytecode(
+    db: &mut LarkDatabase,
+) -> lark_error::WithError<std::sync::Arc<lark_mir::FnBytecode>> {
+    let main_name = "main".intern(&db);
+    let repl_filename = REPL_FILENAME.intern(&db);
+    let entities = db.items_in_file(repl_filename);
+
+    for &entity in &*entities {
+        match entity.untern(&db) {
+            EntityData::ItemName {
+                kind: ItemKind::Function,
+                id,
+                ..
+            } => {
+                if id == main_name {
+                    let bytecode = db.fn_bytecode(entity);
+                    return bytecode;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    panic!("Internal error: Lost track of function bytecode")
+}
+
+pub fn repl() {
+    let mut fn_body: Vec<String> = vec![];
+    let mut io_handler = lark_eval::IOHandler::new(false);
+    let mut db = LarkDatabase::default();
+    let mut variables: HashMap<Variable, Vec<Value>> = HashMap::new();
+    let mut num_to_skip = 0;
+
+    loop {
+        let mut input = String::new();
+
+        print!("> ");
+        let _ = stdout().flush();
+        stdin().read_line(&mut input).expect("Could not read input");
+        input = input.trim().to_string();
+
+        if input == ":q" {
+            break;
+        }
+        if input == ":p" {
+            println!(
+                "Will execute: {}",
+                format!("def main() {{\n{}\n}}", fn_body.join("\n"))
+            );
+            continue;
+        }
+        if input == ":v" {
+            println!("{:#?}", variables);
+            continue;
+        }
+
+        fn_body.push(input);
+
+        let _ = db.add_file(
+            REPL_FILENAME,
+            format!("def main() {{\n{}\n}}", fn_body.join("\n")),
+        );
+
+        let mut error_count = 0;
+        match db.errors_for_project() {
+            Ok(errors) => {
+                for (_filename, ranged_diagnostics) in errors {
+                    for ranged_diagnostic in ranged_diagnostics {
+                        error_count += 1;
+                        println!("{:#?}", ranged_diagnostic);
+                    }
+                }
+            }
+            Err(_) => println!("Internal error: error check internally cancelled"),
+        }
+
+        if error_count > 0 {
+            // The last command was bad. Let's remove it from our function body
+            fn_body.pop();
+        } else {
+            // No errors, so let's run the last line of our function body
+            let fn_bytecode = get_bytecode(&mut db).value;
+
+            //println!("{:#?}", fn_bytecode);
+
+            let mut num_to_skip_remaining = num_to_skip;
+            let mut num_to_skip_next = 0;
+            let mut output = Value::Void;
+
+            for basic_block in fn_bytecode.basic_blocks.iter(&fn_bytecode) {
+                let basic_block_data = &fn_bytecode.tables[basic_block];
+
+                for statement in basic_block_data.statements.iter(&fn_bytecode) {
+                    if num_to_skip_remaining > 0 {
+                        num_to_skip_remaining -= 1;
+                    } else {
+                        let statement_data = &fn_bytecode.tables[statement];
+
+                        match &statement_data.kind {
+                            StatementKind::StorageLive(variable) => {
+                                num_to_skip_next += 1;
+                                // Because we manage our own variables, we have to do a bit of bookkeeping
+                                lark_eval::create_variable(&mut variables, *variable);
+                            }
+                            StatementKind::StorageDead(_) => {
+                                // In the repl, we don't currently delete old variables
+                            }
+                            _ => {
+                                num_to_skip_next += 1;
+                                output = lark_eval::eval_statement(
+                                    &mut db,
+                                    &fn_bytecode,
+                                    statement,
+                                    &mut variables,
+                                    &mut io_handler,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            num_to_skip += num_to_skip_next;
+            match output {
+                Value::Void => {}
+                x => println!("{}", x),
+            }
+        }
+    }
+}

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -1,0 +1,91 @@
+#[cfg(test)]
+mod tests {
+    use languageserver_types::{
+        ClientCapabilities, DidOpenTextDocumentParams, InitializeParams, InitializeResult,
+        PublishDiagnosticsParams, TextDocumentItem,
+    };
+    use lark_language_server::{JsonRPCNotification, JsonRPCResponse, LSPCommand};
+    use serde::{Deserialize, Serialize};
+    use std::io::{Read, Write};
+    use std::panic;
+    use std::process::{Command, Stdio};
+
+    struct ChildSession {
+        child: std::process::Child,
+    }
+
+    impl Drop for ChildSession {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+        }
+    }
+
+    impl ChildSession {
+        fn spawn() -> ChildSession {
+            let child = Command::new("cargo")
+                .arg("run")
+                .arg("--")
+                .arg("repl")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn child process");
+
+            ChildSession { child }
+        }
+        /// Helper function to do the work of sending a result back to the IDE
+        fn send(&mut self, msg: &str) -> Result<(), Box<std::error::Error>> {
+            let child_stdin = self.child.stdin.as_mut().ok_or(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "can connect to child stdin",
+            ))?;
+
+            child_stdin
+                .write_all(msg.as_bytes())
+                .expect("Failed to write to stdin");
+            //let _ = io::stdout().flush();
+
+            Ok(())
+        }
+
+        fn receive(&mut self) -> Result<String, Box<std::error::Error>> {
+            let child_stdout = self.child.stdout.as_mut().ok_or(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "can connect to child stdout",
+            ))?;
+
+            let mut buffer = String::new();
+            let mut character = [0; 1];
+            loop {
+                child_stdout.read(&mut character[..])?;
+                let ch = character[0] as char;
+
+                eprintln!("{}", ch);
+
+                buffer.push(ch);
+
+                if ch == '>' {
+                    eprintln!("break");
+                    break;
+                }
+            }
+
+            Ok(buffer)
+        }
+    }
+
+    #[test]
+    fn repl_test_assignment() {
+        let mut child_session = ChildSession::spawn();
+
+        let _ = child_session.receive();
+
+        child_session.send("let x = true\n");
+        let result = child_session.receive();
+
+        child_session.send("debug(x)\n");
+        let result = child_session.receive().unwrap();
+
+        assert_eq!(result, " true\n>");
+    }
+}


### PR DESCRIPTION
This adds a simple repl to Lark with a few basic commands (mostly for debugging inspection). It also adds a repl test and a framework we can use to add more tests in the future.