### PR TITLE
Move LSP test to use test_files dir

### DIFF
--- a/tests/language_server.rs
+++ b/tests/language_server.rs
@@ -139,7 +139,7 @@ mod tests {
         assert_eq!(result.id, 100);
 
         // Open the document
-        child_session.send_open("samples/minimal.lark")?;
+        child_session.send_open("tests/test_files/error_type_mismatch.lark")?;
 
         let result = child_session.receive::<JsonRPCNotification<PublishDiagnosticsParams>>()?;
         assert_eq!(result.method, "textDocument/publishDiagnostics",);

--- a/tests/test_files/error_type_mismatch.lark
+++ b/tests/test_files/error_type_mismatch.lark
@@ -1,0 +1,6 @@
+struct Diagnostic {
+  msg: own bool,
+  level: bool,
+}
+
+def foo(x: bool, y: uint) -> bool { y }


### PR DESCRIPTION
We shouldn't use samples directory for our integration tests. Pulling this file, which the LSP test was using, into the test_files dir