### PR TITLE
parse struct constructors correctly, add tests

### DIFF
--- a/tests/type_checker/main.rs
+++ b/tests/type_checker/main.rs
@@ -64,3 +64,19 @@ fn struct_field_uint_vs_uint() {
         NoErrors,
     );
 }
+
+#[test]
+fn struct_ctor_correct_arg_type() {
+    run_test(
+        "struct Foo { b: bool } def make() -> Foo { Foo(b: true) }",
+        NoErrors,
+    );
+}
+
+#[test]
+fn struct_ctor_wrong_arg_type() {
+    run_test(
+        "struct Foo { b: bool } def make() -> Foo { Foo(b: 22) }",
+        "                                                  ~~",
+    );
+}


### PR DESCRIPTION
We needed some lookahead to distinguish `foo(x: 22)` from an ordinary
call (eventually I hope for the two forms to be unified).