### PR TITLE
Binary search cache line indices to improve stresstest

### DIFF
--- a/components/lark-query-system/src/ls_ops.rs
+++ b/components/lark-query-system/src/ls_ops.rs
@@ -58,9 +58,24 @@ pub trait LsDatabase: lark_type_check::TypeCheckDatabase {
 
             let text = self.file_text(input_file);
 
+            let text_length = text.len();
+
+            let source_line_indices: Vec<usize> = text
+                .match_indices("\n")
+                .into_iter()
+                .map(|(x, _)| x)
+                .collect();
+
             let error_ranges = errors
                 .iter()
-                .map(|x| RangedDiagnostic::new(x.label.clone(), x.span.to_range(&text).unwrap()))
+                .map(|x| {
+                    RangedDiagnostic::new(
+                        x.label.clone(),
+                        x.span
+                            .to_range_with_line_indices(&source_line_indices, text_length)
+                            .unwrap(),
+                    )
+                })
                 .collect();
 
             file_errors.insert(input_file.id.untern(self).to_string(), error_ranges);

--- a/components/lark-span/src/span.rs
+++ b/components/lark-span/src/span.rs
@@ -122,6 +122,27 @@ impl<File: SpanFile> Span<File> {
 
         Ok(languageserver_types::Range::new(left, right))
     }
+
+    pub fn to_range_with_line_indices(
+        &self,
+        source_line_indices: &Vec<usize>,
+        source_len: usize,
+    ) -> Result<languageserver_types::Range, OutOfBounds> {
+        let left = Location::from_index_with_line_indices(
+            source_line_indices,
+            source_len,
+            self.start,
+        )?
+        .as_position();
+        let right = Location::from_index_with_line_indices(
+            source_line_indices,
+            source_len,
+            self.end,
+        )?
+        .as_position();
+
+        Ok(languageserver_types::Range::new(left, right))
+    }
 }
 
 impl<F: SpanFile> l_r::ReportingSpan for Span<F> {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -76,7 +76,7 @@
 	"devDependencies": {
 		"@types/mocha": "^5.2.0",
 		"@types/node": "^8.0.0",
-		"typescript": "2.8.3",
-		"shelljs": "^0.8.2"
+		"shelljs": "^0.8.2",
+		"typescript": "2.8.3"
 	}
 }

--- a/editors/vscode/yarn.lock
+++ b/editors/vscode/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==
 
 "@types/node@^8.0.0":
-  version "8.10.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.37.tgz#d2db49dc6a4e087c3245f22b92061f22494771e5"
-  integrity sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==
+  version "8.10.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
+  integrity sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -104,9 +104,9 @@ resolve@^1.1.6:
     path-parse "^1.0.5"
 
 shelljs@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
-  integrity sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"

--- a/tests/test_files/error_stresstest.lark
+++ b/tests/test_files/error_stresstest.lark
@@ -1,0 +1,6514 @@
+struct Diagnostic0 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+  level: bool,
+  //~ ERROR
+         //~ ERROR
+         //~ ERROR
+             //~ ERROR
+}
+//~ ERROR
+struct Diagnostic1 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic2 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic3 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic4 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic5 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic6 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic7 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic8 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic9 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic10 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic11 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic12 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic13 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic14 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic15 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic16 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic17 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic18 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic19 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic20 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic21 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic22 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic23 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic24 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic25 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic26 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic27 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic28 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic29 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic30 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic31 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic32 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic33 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic34 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic35 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic36 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic37 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic38 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic39 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic40 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic41 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic42 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic43 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic44 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic45 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic46 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic47 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic48 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic49 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic50 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic51 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic52 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic53 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic54 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic55 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic56 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic57 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic58 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic59 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic60 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic61 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic62 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic63 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic64 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic65 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic66 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic67 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic68 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic69 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic70 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic71 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic72 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic73 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic74 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic75 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic76 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic77 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic78 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic79 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic80 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic81 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic82 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic83 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic84 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic85 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic86 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic87 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic88 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic89 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic90 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic91 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic92 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic93 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic94 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic95 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic96 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic97 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic98 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic99 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic100 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic101 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic102 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic103 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic104 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic105 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic106 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic107 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic108 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic109 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic110 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic111 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic112 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic113 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic114 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic115 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic116 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic117 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic118 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic119 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic120 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic121 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic122 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic123 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic124 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic125 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic126 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic127 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic128 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic129 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic130 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic131 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic132 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic133 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic134 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic135 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic136 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic137 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic138 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic139 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic140 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic141 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic142 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic143 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic144 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic145 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic146 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic147 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic148 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic149 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic150 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic151 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic152 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic153 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic154 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic155 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic156 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic157 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic158 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic159 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic160 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic161 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic162 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic163 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic164 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic165 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic166 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic167 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic168 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic169 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic170 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic171 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic172 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic173 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic174 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic175 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic176 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic177 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic178 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic179 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic180 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic181 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic182 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic183 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic184 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic185 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic186 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic187 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic188 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic189 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic190 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic191 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic192 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic193 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic194 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic195 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic196 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic197 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic198 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic199 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic200 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic201 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic202 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic203 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic204 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic205 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic206 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic207 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic208 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic209 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic210 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic211 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic212 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic213 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic214 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic215 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic216 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic217 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic218 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic219 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic220 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic221 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic222 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic223 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic224 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic225 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic226 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic227 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic228 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic229 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic230 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic231 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic232 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic233 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic234 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic235 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic236 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic237 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic238 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic239 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic240 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic241 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic242 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic243 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic244 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic245 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic246 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic247 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic248 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic249 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic250 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic251 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic252 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic253 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic254 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic255 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic256 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic257 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic258 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic259 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic260 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic261 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic262 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic263 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic264 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic265 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic266 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic267 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic268 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic269 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic270 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic271 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic272 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic273 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic274 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic275 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic276 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic277 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic278 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic279 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic280 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic281 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic282 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic283 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic284 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic285 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic286 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic287 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic288 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic289 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic290 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic291 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic292 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic293 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic294 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic295 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic296 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic297 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic298 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic299 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic300 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic301 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic302 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic303 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic304 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic305 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic306 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic307 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic308 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic309 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic310 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic311 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic312 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic313 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic314 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic315 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic316 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic317 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic318 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic319 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic320 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic321 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic322 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic323 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic324 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic325 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic326 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic327 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic328 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic329 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic330 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic331 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic332 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic333 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic334 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic335 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic336 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic337 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic338 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic339 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic340 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic341 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic342 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic343 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic344 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic345 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic346 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic347 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic348 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic349 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic350 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic351 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic352 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic353 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic354 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic355 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic356 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic357 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic358 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic359 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic360 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic361 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic362 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic363 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic364 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic365 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic366 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic367 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic368 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic369 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic370 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic371 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic372 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic373 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic374 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic375 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic376 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic377 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic378 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic379 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic380 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic381 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic382 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic383 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic384 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic385 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic386 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic387 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic388 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic389 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic390 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic391 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic392 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic393 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic394 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic395 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic396 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic397 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic398 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic399 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic400 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic401 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic402 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic403 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic404 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic405 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic406 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic407 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic408 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic409 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic410 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic411 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic412 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic413 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic414 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic415 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic416 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic417 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic418 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic419 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic420 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic421 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic422 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic423 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic424 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic425 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic426 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic427 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic428 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic429 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic430 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic431 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic432 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic433 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic434 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic435 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic436 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic437 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic438 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic439 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic440 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic441 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic442 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic443 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic444 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic445 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic446 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic447 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic448 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic449 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic450 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic451 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic452 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic453 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic454 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic455 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic456 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic457 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic458 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic459 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic460 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic461 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic462 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic463 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic464 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic465 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic466 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic467 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic468 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic469 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic470 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic471 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic472 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic473 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic474 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic475 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic476 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic477 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic478 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic479 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic480 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic481 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic482 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic483 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic484 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic485 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic486 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic487 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic488 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic489 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic490 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic491 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic492 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic493 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic494 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic495 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic496 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic497 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic498 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic499 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+struct Diagnostic500 {
+  msg: own bool,
+       //~ ERROR
+       //~ ERROR
+               //~ ERROR
+   level: bool,
+   //~ ERROR
+          //~ ERROR
+          //~ ERROR
+              //~ ERROR
+}
+//~ ERROR
+
+def main() {
+}

--- a/tests/test_files/error_stresstest.stderr
+++ b/tests/test_files/error_stresstest.stderr
@@ -1,0 +1,16032 @@
+error: expected `}`
+- error_stresstest:2:11
+2 |   msg: own bool,
+  |            ^^^^
+error: no macro with this name
+- error_stresstest:2:11
+2 |   msg: own bool,
+  |            ^^^^
+error: unexpected character
+- error_stresstest:2:15
+2 |   msg: own bool,
+  |                ^
+error: no macro with this name
+- error_stresstest:6:2
+6 |   level: bool,
+  |   ^^^^^
+error: unexpected character
+- error_stresstest:6:7
+6 |   level: bool,
+  |        ^
+error: no macro with this name
+- error_stresstest:6:9
+6 |   level: bool,
+  |          ^^^^
+error: unexpected character
+- error_stresstest:6:13
+6 |   level: bool,
+  |              ^
+error: unexpected character
+- error_stresstest:11:0
+11 | }
+   | ^
+error: expected `}`
+- error_stresstest:14:11
+14 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:14:11
+14 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:14:15
+14 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:18:3
+18 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:18:8
+18 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:18:10
+18 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:18:14
+18 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:23:0
+23 | }
+   | ^
+error: expected `}`
+- error_stresstest:27:11
+27 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:27:11
+27 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:27:15
+27 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:31:3
+31 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:31:8
+31 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:31:10
+31 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:31:14
+31 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:36:0
+36 | }
+   | ^
+error: expected `}`
+- error_stresstest:40:11
+40 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:40:11
+40 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:40:15
+40 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:44:3
+44 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:44:8
+44 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:44:10
+44 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:44:14
+44 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:49:0
+49 | }
+   | ^
+error: expected `}`
+- error_stresstest:53:11
+53 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:53:11
+53 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:53:15
+53 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:57:3
+57 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:57:8
+57 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:57:10
+57 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:57:14
+57 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:62:0
+62 | }
+   | ^
+error: expected `}`
+- error_stresstest:66:11
+66 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:66:11
+66 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:66:15
+66 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:70:3
+70 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:70:8
+70 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:70:10
+70 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:70:14
+70 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:75:0
+75 | }
+   | ^
+error: expected `}`
+- error_stresstest:79:11
+79 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:79:11
+79 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:79:15
+79 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:83:3
+83 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:83:8
+83 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:83:10
+83 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:83:14
+83 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:88:0
+88 | }
+   | ^
+error: expected `}`
+- error_stresstest:92:11
+92 |   msg: own bool,
+   |            ^^^^
+error: no macro with this name
+- error_stresstest:92:11
+92 |   msg: own bool,
+   |            ^^^^
+error: unexpected character
+- error_stresstest:92:15
+92 |   msg: own bool,
+   |                ^
+error: no macro with this name
+- error_stresstest:96:3
+96 |    level: bool,
+   |    ^^^^^
+error: unexpected character
+- error_stresstest:96:8
+96 |    level: bool,
+   |         ^
+error: no macro with this name
+- error_stresstest:96:10
+96 |    level: bool,
+   |           ^^^^
+error: unexpected character
+- error_stresstest:96:14
+96 |    level: bool,
+   |               ^
+error: unexpected character
+- error_stresstest:101:0
+101 | }
+    | ^
+error: expected `}`
+- error_stresstest:105:11
+105 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:105:11
+105 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:105:15
+105 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:109:3
+109 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:109:8
+109 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:109:10
+109 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:109:14
+109 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:114:0
+114 | }
+    | ^
+error: expected `}`
+- error_stresstest:118:11
+118 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:118:11
+118 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:118:15
+118 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:122:3
+122 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:122:8
+122 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:122:10
+122 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:122:14
+122 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:127:0
+127 | }
+    | ^
+error: expected `}`
+- error_stresstest:131:11
+131 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:131:11
+131 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:131:15
+131 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:135:3
+135 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:135:8
+135 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:135:10
+135 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:135:14
+135 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:140:0
+140 | }
+    | ^
+error: expected `}`
+- error_stresstest:144:11
+144 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:144:11
+144 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:144:15
+144 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:148:3
+148 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:148:8
+148 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:148:10
+148 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:148:14
+148 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:153:0
+153 | }
+    | ^
+error: expected `}`
+- error_stresstest:157:11
+157 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:157:11
+157 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:157:15
+157 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:161:3
+161 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:161:8
+161 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:161:10
+161 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:161:14
+161 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:166:0
+166 | }
+    | ^
+error: expected `}`
+- error_stresstest:170:11
+170 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:170:11
+170 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:170:15
+170 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:174:3
+174 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:174:8
+174 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:174:10
+174 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:174:14
+174 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:179:0
+179 | }
+    | ^
+error: expected `}`
+- error_stresstest:183:11
+183 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:183:11
+183 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:183:15
+183 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:187:3
+187 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:187:8
+187 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:187:10
+187 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:187:14
+187 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:192:0
+192 | }
+    | ^
+error: expected `}`
+- error_stresstest:196:11
+196 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:196:11
+196 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:196:15
+196 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:200:3
+200 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:200:8
+200 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:200:10
+200 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:200:14
+200 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:205:0
+205 | }
+    | ^
+error: expected `}`
+- error_stresstest:209:11
+209 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:209:11
+209 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:209:15
+209 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:213:3
+213 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:213:8
+213 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:213:10
+213 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:213:14
+213 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:218:0
+218 | }
+    | ^
+error: expected `}`
+- error_stresstest:222:11
+222 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:222:11
+222 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:222:15
+222 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:226:3
+226 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:226:8
+226 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:226:10
+226 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:226:14
+226 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:231:0
+231 | }
+    | ^
+error: expected `}`
+- error_stresstest:235:11
+235 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:235:11
+235 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:235:15
+235 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:239:3
+239 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:239:8
+239 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:239:10
+239 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:239:14
+239 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:244:0
+244 | }
+    | ^
+error: expected `}`
+- error_stresstest:248:11
+248 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:248:11
+248 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:248:15
+248 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:252:3
+252 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:252:8
+252 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:252:10
+252 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:252:14
+252 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:257:0
+257 | }
+    | ^
+error: expected `}`
+- error_stresstest:261:11
+261 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:261:11
+261 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:261:15
+261 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:265:3
+265 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:265:8
+265 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:265:10
+265 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:265:14
+265 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:270:0
+270 | }
+    | ^
+error: expected `}`
+- error_stresstest:274:11
+274 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:274:11
+274 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:274:15
+274 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:278:3
+278 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:278:8
+278 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:278:10
+278 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:278:14
+278 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:283:0
+283 | }
+    | ^
+error: expected `}`
+- error_stresstest:287:11
+287 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:287:11
+287 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:287:15
+287 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:291:3
+291 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:291:8
+291 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:291:10
+291 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:291:14
+291 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:296:0
+296 | }
+    | ^
+error: expected `}`
+- error_stresstest:300:11
+300 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:300:11
+300 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:300:15
+300 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:304:3
+304 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:304:8
+304 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:304:10
+304 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:304:14
+304 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:309:0
+309 | }
+    | ^
+error: expected `}`
+- error_stresstest:313:11
+313 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:313:11
+313 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:313:15
+313 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:317:3
+317 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:317:8
+317 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:317:10
+317 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:317:14
+317 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:322:0
+322 | }
+    | ^
+error: expected `}`
+- error_stresstest:326:11
+326 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:326:11
+326 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:326:15
+326 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:330:3
+330 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:330:8
+330 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:330:10
+330 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:330:14
+330 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:335:0
+335 | }
+    | ^
+error: expected `}`
+- error_stresstest:339:11
+339 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:339:11
+339 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:339:15
+339 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:343:3
+343 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:343:8
+343 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:343:10
+343 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:343:14
+343 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:348:0
+348 | }
+    | ^
+error: expected `}`
+- error_stresstest:352:11
+352 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:352:11
+352 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:352:15
+352 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:356:3
+356 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:356:8
+356 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:356:10
+356 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:356:14
+356 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:361:0
+361 | }
+    | ^
+error: expected `}`
+- error_stresstest:365:11
+365 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:365:11
+365 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:365:15
+365 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:369:3
+369 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:369:8
+369 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:369:10
+369 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:369:14
+369 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:374:0
+374 | }
+    | ^
+error: expected `}`
+- error_stresstest:378:11
+378 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:378:11
+378 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:378:15
+378 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:382:3
+382 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:382:8
+382 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:382:10
+382 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:382:14
+382 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:387:0
+387 | }
+    | ^
+error: expected `}`
+- error_stresstest:391:11
+391 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:391:11
+391 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:391:15
+391 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:395:3
+395 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:395:8
+395 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:395:10
+395 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:395:14
+395 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:400:0
+400 | }
+    | ^
+error: expected `}`
+- error_stresstest:404:11
+404 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:404:11
+404 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:404:15
+404 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:408:3
+408 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:408:8
+408 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:408:10
+408 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:408:14
+408 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:413:0
+413 | }
+    | ^
+error: expected `}`
+- error_stresstest:417:11
+417 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:417:11
+417 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:417:15
+417 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:421:3
+421 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:421:8
+421 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:421:10
+421 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:421:14
+421 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:426:0
+426 | }
+    | ^
+error: expected `}`
+- error_stresstest:430:11
+430 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:430:11
+430 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:430:15
+430 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:434:3
+434 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:434:8
+434 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:434:10
+434 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:434:14
+434 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:439:0
+439 | }
+    | ^
+error: expected `}`
+- error_stresstest:443:11
+443 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:443:11
+443 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:443:15
+443 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:447:3
+447 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:447:8
+447 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:447:10
+447 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:447:14
+447 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:452:0
+452 | }
+    | ^
+error: expected `}`
+- error_stresstest:456:11
+456 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:456:11
+456 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:456:15
+456 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:460:3
+460 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:460:8
+460 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:460:10
+460 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:460:14
+460 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:465:0
+465 | }
+    | ^
+error: expected `}`
+- error_stresstest:469:11
+469 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:469:11
+469 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:469:15
+469 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:473:3
+473 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:473:8
+473 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:473:10
+473 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:473:14
+473 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:478:0
+478 | }
+    | ^
+error: expected `}`
+- error_stresstest:482:11
+482 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:482:11
+482 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:482:15
+482 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:486:3
+486 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:486:8
+486 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:486:10
+486 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:486:14
+486 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:491:0
+491 | }
+    | ^
+error: expected `}`
+- error_stresstest:495:11
+495 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:495:11
+495 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:495:15
+495 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:499:3
+499 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:499:8
+499 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:499:10
+499 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:499:14
+499 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:504:0
+504 | }
+    | ^
+error: expected `}`
+- error_stresstest:508:11
+508 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:508:11
+508 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:508:15
+508 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:512:3
+512 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:512:8
+512 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:512:10
+512 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:512:14
+512 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:517:0
+517 | }
+    | ^
+error: expected `}`
+- error_stresstest:521:11
+521 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:521:11
+521 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:521:15
+521 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:525:3
+525 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:525:8
+525 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:525:10
+525 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:525:14
+525 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:530:0
+530 | }
+    | ^
+error: expected `}`
+- error_stresstest:534:11
+534 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:534:11
+534 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:534:15
+534 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:538:3
+538 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:538:8
+538 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:538:10
+538 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:538:14
+538 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:543:0
+543 | }
+    | ^
+error: expected `}`
+- error_stresstest:547:11
+547 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:547:11
+547 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:547:15
+547 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:551:3
+551 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:551:8
+551 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:551:10
+551 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:551:14
+551 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:556:0
+556 | }
+    | ^
+error: expected `}`
+- error_stresstest:560:11
+560 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:560:11
+560 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:560:15
+560 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:564:3
+564 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:564:8
+564 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:564:10
+564 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:564:14
+564 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:569:0
+569 | }
+    | ^
+error: expected `}`
+- error_stresstest:573:11
+573 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:573:11
+573 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:573:15
+573 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:577:3
+577 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:577:8
+577 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:577:10
+577 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:577:14
+577 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:582:0
+582 | }
+    | ^
+error: expected `}`
+- error_stresstest:586:11
+586 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:586:11
+586 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:586:15
+586 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:590:3
+590 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:590:8
+590 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:590:10
+590 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:590:14
+590 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:595:0
+595 | }
+    | ^
+error: expected `}`
+- error_stresstest:599:11
+599 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:599:11
+599 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:599:15
+599 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:603:3
+603 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:603:8
+603 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:603:10
+603 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:603:14
+603 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:608:0
+608 | }
+    | ^
+error: expected `}`
+- error_stresstest:612:11
+612 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:612:11
+612 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:612:15
+612 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:616:3
+616 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:616:8
+616 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:616:10
+616 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:616:14
+616 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:621:0
+621 | }
+    | ^
+error: expected `}`
+- error_stresstest:625:11
+625 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:625:11
+625 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:625:15
+625 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:629:3
+629 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:629:8
+629 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:629:10
+629 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:629:14
+629 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:634:0
+634 | }
+    | ^
+error: expected `}`
+- error_stresstest:638:11
+638 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:638:11
+638 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:638:15
+638 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:642:3
+642 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:642:8
+642 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:642:10
+642 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:642:14
+642 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:647:0
+647 | }
+    | ^
+error: expected `}`
+- error_stresstest:651:11
+651 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:651:11
+651 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:651:15
+651 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:655:3
+655 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:655:8
+655 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:655:10
+655 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:655:14
+655 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:660:0
+660 | }
+    | ^
+error: expected `}`
+- error_stresstest:664:11
+664 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:664:11
+664 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:664:15
+664 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:668:3
+668 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:668:8
+668 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:668:10
+668 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:668:14
+668 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:673:0
+673 | }
+    | ^
+error: expected `}`
+- error_stresstest:677:11
+677 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:677:11
+677 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:677:15
+677 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:681:3
+681 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:681:8
+681 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:681:10
+681 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:681:14
+681 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:686:0
+686 | }
+    | ^
+error: expected `}`
+- error_stresstest:690:11
+690 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:690:11
+690 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:690:15
+690 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:694:3
+694 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:694:8
+694 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:694:10
+694 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:694:14
+694 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:699:0
+699 | }
+    | ^
+error: expected `}`
+- error_stresstest:703:11
+703 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:703:11
+703 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:703:15
+703 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:707:3
+707 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:707:8
+707 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:707:10
+707 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:707:14
+707 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:712:0
+712 | }
+    | ^
+error: expected `}`
+- error_stresstest:716:11
+716 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:716:11
+716 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:716:15
+716 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:720:3
+720 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:720:8
+720 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:720:10
+720 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:720:14
+720 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:725:0
+725 | }
+    | ^
+error: expected `}`
+- error_stresstest:729:11
+729 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:729:11
+729 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:729:15
+729 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:733:3
+733 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:733:8
+733 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:733:10
+733 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:733:14
+733 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:738:0
+738 | }
+    | ^
+error: expected `}`
+- error_stresstest:742:11
+742 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:742:11
+742 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:742:15
+742 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:746:3
+746 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:746:8
+746 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:746:10
+746 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:746:14
+746 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:751:0
+751 | }
+    | ^
+error: expected `}`
+- error_stresstest:755:11
+755 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:755:11
+755 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:755:15
+755 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:759:3
+759 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:759:8
+759 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:759:10
+759 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:759:14
+759 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:764:0
+764 | }
+    | ^
+error: expected `}`
+- error_stresstest:768:11
+768 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:768:11
+768 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:768:15
+768 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:772:3
+772 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:772:8
+772 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:772:10
+772 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:772:14
+772 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:777:0
+777 | }
+    | ^
+error: expected `}`
+- error_stresstest:781:11
+781 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:781:11
+781 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:781:15
+781 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:785:3
+785 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:785:8
+785 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:785:10
+785 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:785:14
+785 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:790:0
+790 | }
+    | ^
+error: expected `}`
+- error_stresstest:794:11
+794 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:794:11
+794 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:794:15
+794 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:798:3
+798 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:798:8
+798 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:798:10
+798 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:798:14
+798 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:803:0
+803 | }
+    | ^
+error: expected `}`
+- error_stresstest:807:11
+807 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:807:11
+807 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:807:15
+807 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:811:3
+811 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:811:8
+811 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:811:10
+811 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:811:14
+811 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:816:0
+816 | }
+    | ^
+error: expected `}`
+- error_stresstest:820:11
+820 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:820:11
+820 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:820:15
+820 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:824:3
+824 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:824:8
+824 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:824:10
+824 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:824:14
+824 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:829:0
+829 | }
+    | ^
+error: expected `}`
+- error_stresstest:833:11
+833 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:833:11
+833 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:833:15
+833 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:837:3
+837 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:837:8
+837 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:837:10
+837 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:837:14
+837 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:842:0
+842 | }
+    | ^
+error: expected `}`
+- error_stresstest:846:11
+846 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:846:11
+846 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:846:15
+846 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:850:3
+850 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:850:8
+850 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:850:10
+850 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:850:14
+850 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:855:0
+855 | }
+    | ^
+error: expected `}`
+- error_stresstest:859:11
+859 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:859:11
+859 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:859:15
+859 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:863:3
+863 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:863:8
+863 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:863:10
+863 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:863:14
+863 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:868:0
+868 | }
+    | ^
+error: expected `}`
+- error_stresstest:872:11
+872 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:872:11
+872 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:872:15
+872 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:876:3
+876 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:876:8
+876 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:876:10
+876 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:876:14
+876 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:881:0
+881 | }
+    | ^
+error: expected `}`
+- error_stresstest:885:11
+885 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:885:11
+885 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:885:15
+885 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:889:3
+889 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:889:8
+889 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:889:10
+889 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:889:14
+889 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:894:0
+894 | }
+    | ^
+error: expected `}`
+- error_stresstest:898:11
+898 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:898:11
+898 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:898:15
+898 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:902:3
+902 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:902:8
+902 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:902:10
+902 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:902:14
+902 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:907:0
+907 | }
+    | ^
+error: expected `}`
+- error_stresstest:911:11
+911 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:911:11
+911 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:911:15
+911 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:915:3
+915 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:915:8
+915 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:915:10
+915 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:915:14
+915 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:920:0
+920 | }
+    | ^
+error: expected `}`
+- error_stresstest:924:11
+924 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:924:11
+924 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:924:15
+924 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:928:3
+928 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:928:8
+928 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:928:10
+928 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:928:14
+928 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:933:0
+933 | }
+    | ^
+error: expected `}`
+- error_stresstest:937:11
+937 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:937:11
+937 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:937:15
+937 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:941:3
+941 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:941:8
+941 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:941:10
+941 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:941:14
+941 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:946:0
+946 | }
+    | ^
+error: expected `}`
+- error_stresstest:950:11
+950 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:950:11
+950 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:950:15
+950 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:954:3
+954 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:954:8
+954 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:954:10
+954 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:954:14
+954 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:959:0
+959 | }
+    | ^
+error: expected `}`
+- error_stresstest:963:11
+963 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:963:11
+963 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:963:15
+963 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:967:3
+967 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:967:8
+967 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:967:10
+967 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:967:14
+967 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:972:0
+972 | }
+    | ^
+error: expected `}`
+- error_stresstest:976:11
+976 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:976:11
+976 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:976:15
+976 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:980:3
+980 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:980:8
+980 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:980:10
+980 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:980:14
+980 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:985:0
+985 | }
+    | ^
+error: expected `}`
+- error_stresstest:989:11
+989 |   msg: own bool,
+    |            ^^^^
+error: no macro with this name
+- error_stresstest:989:11
+989 |   msg: own bool,
+    |            ^^^^
+error: unexpected character
+- error_stresstest:989:15
+989 |   msg: own bool,
+    |                ^
+error: no macro with this name
+- error_stresstest:993:3
+993 |    level: bool,
+    |    ^^^^^
+error: unexpected character
+- error_stresstest:993:8
+993 |    level: bool,
+    |         ^
+error: no macro with this name
+- error_stresstest:993:10
+993 |    level: bool,
+    |           ^^^^
+error: unexpected character
+- error_stresstest:993:14
+993 |    level: bool,
+    |               ^
+error: unexpected character
+- error_stresstest:998:0
+998 | }
+    | ^
+error: expected `}`
+- error_stresstest:1002:11
+1002 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1002:11
+1002 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1002:15
+1002 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1006:3
+1006 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1006:8
+1006 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1006:10
+1006 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1006:14
+1006 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1011:0
+1011 | }
+     | ^
+error: expected `}`
+- error_stresstest:1015:11
+1015 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1015:11
+1015 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1015:15
+1015 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1019:3
+1019 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1019:8
+1019 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1019:10
+1019 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1019:14
+1019 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1024:0
+1024 | }
+     | ^
+error: expected `}`
+- error_stresstest:1028:11
+1028 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1028:11
+1028 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1028:15
+1028 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1032:3
+1032 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1032:8
+1032 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1032:10
+1032 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1032:14
+1032 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1037:0
+1037 | }
+     | ^
+error: expected `}`
+- error_stresstest:1041:11
+1041 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1041:11
+1041 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1041:15
+1041 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1045:3
+1045 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1045:8
+1045 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1045:10
+1045 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1045:14
+1045 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1050:0
+1050 | }
+     | ^
+error: expected `}`
+- error_stresstest:1054:11
+1054 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1054:11
+1054 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1054:15
+1054 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1058:3
+1058 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1058:8
+1058 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1058:10
+1058 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1058:14
+1058 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1063:0
+1063 | }
+     | ^
+error: expected `}`
+- error_stresstest:1067:11
+1067 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1067:11
+1067 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1067:15
+1067 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1071:3
+1071 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1071:8
+1071 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1071:10
+1071 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1071:14
+1071 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1076:0
+1076 | }
+     | ^
+error: expected `}`
+- error_stresstest:1080:11
+1080 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1080:11
+1080 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1080:15
+1080 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1084:3
+1084 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1084:8
+1084 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1084:10
+1084 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1084:14
+1084 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1089:0
+1089 | }
+     | ^
+error: expected `}`
+- error_stresstest:1093:11
+1093 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1093:11
+1093 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1093:15
+1093 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1097:3
+1097 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1097:8
+1097 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1097:10
+1097 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1097:14
+1097 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1102:0
+1102 | }
+     | ^
+error: expected `}`
+- error_stresstest:1106:11
+1106 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1106:11
+1106 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1106:15
+1106 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1110:3
+1110 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1110:8
+1110 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1110:10
+1110 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1110:14
+1110 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1115:0
+1115 | }
+     | ^
+error: expected `}`
+- error_stresstest:1119:11
+1119 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1119:11
+1119 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1119:15
+1119 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1123:3
+1123 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1123:8
+1123 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1123:10
+1123 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1123:14
+1123 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1128:0
+1128 | }
+     | ^
+error: expected `}`
+- error_stresstest:1132:11
+1132 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1132:11
+1132 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1132:15
+1132 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1136:3
+1136 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1136:8
+1136 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1136:10
+1136 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1136:14
+1136 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1141:0
+1141 | }
+     | ^
+error: expected `}`
+- error_stresstest:1145:11
+1145 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1145:11
+1145 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1145:15
+1145 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1149:3
+1149 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1149:8
+1149 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1149:10
+1149 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1149:14
+1149 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1154:0
+1154 | }
+     | ^
+error: expected `}`
+- error_stresstest:1158:11
+1158 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1158:11
+1158 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1158:15
+1158 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1162:3
+1162 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1162:8
+1162 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1162:10
+1162 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1162:14
+1162 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1167:0
+1167 | }
+     | ^
+error: expected `}`
+- error_stresstest:1171:11
+1171 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1171:11
+1171 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1171:15
+1171 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1175:3
+1175 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1175:8
+1175 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1175:10
+1175 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1175:14
+1175 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1180:0
+1180 | }
+     | ^
+error: expected `}`
+- error_stresstest:1184:11
+1184 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1184:11
+1184 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1184:15
+1184 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1188:3
+1188 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1188:8
+1188 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1188:10
+1188 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1188:14
+1188 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1193:0
+1193 | }
+     | ^
+error: expected `}`
+- error_stresstest:1197:11
+1197 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1197:11
+1197 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1197:15
+1197 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1201:3
+1201 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1201:8
+1201 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1201:10
+1201 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1201:14
+1201 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1206:0
+1206 | }
+     | ^
+error: expected `}`
+- error_stresstest:1210:11
+1210 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1210:11
+1210 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1210:15
+1210 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1214:3
+1214 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1214:8
+1214 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1214:10
+1214 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1214:14
+1214 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1219:0
+1219 | }
+     | ^
+error: expected `}`
+- error_stresstest:1223:11
+1223 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1223:11
+1223 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1223:15
+1223 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1227:3
+1227 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1227:8
+1227 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1227:10
+1227 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1227:14
+1227 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1232:0
+1232 | }
+     | ^
+error: expected `}`
+- error_stresstest:1236:11
+1236 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1236:11
+1236 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1236:15
+1236 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1240:3
+1240 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1240:8
+1240 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1240:10
+1240 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1240:14
+1240 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1245:0
+1245 | }
+     | ^
+error: expected `}`
+- error_stresstest:1249:11
+1249 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1249:11
+1249 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1249:15
+1249 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1253:3
+1253 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1253:8
+1253 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1253:10
+1253 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1253:14
+1253 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1258:0
+1258 | }
+     | ^
+error: expected `}`
+- error_stresstest:1262:11
+1262 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1262:11
+1262 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1262:15
+1262 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1266:3
+1266 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1266:8
+1266 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1266:10
+1266 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1266:14
+1266 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1271:0
+1271 | }
+     | ^
+error: expected `}`
+- error_stresstest:1275:11
+1275 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1275:11
+1275 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1275:15
+1275 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1279:3
+1279 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1279:8
+1279 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1279:10
+1279 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1279:14
+1279 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1284:0
+1284 | }
+     | ^
+error: expected `}`
+- error_stresstest:1288:11
+1288 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1288:11
+1288 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1288:15
+1288 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1292:3
+1292 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1292:8
+1292 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1292:10
+1292 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1292:14
+1292 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1297:0
+1297 | }
+     | ^
+error: expected `}`
+- error_stresstest:1301:11
+1301 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1301:11
+1301 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1301:15
+1301 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1305:3
+1305 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1305:8
+1305 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1305:10
+1305 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1305:14
+1305 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1310:0
+1310 | }
+     | ^
+error: expected `}`
+- error_stresstest:1314:11
+1314 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1314:11
+1314 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1314:15
+1314 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1318:3
+1318 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1318:8
+1318 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1318:10
+1318 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1318:14
+1318 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1323:0
+1323 | }
+     | ^
+error: expected `}`
+- error_stresstest:1327:11
+1327 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1327:11
+1327 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1327:15
+1327 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1331:3
+1331 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1331:8
+1331 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1331:10
+1331 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1331:14
+1331 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1336:0
+1336 | }
+     | ^
+error: expected `}`
+- error_stresstest:1340:11
+1340 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1340:11
+1340 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1340:15
+1340 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1344:3
+1344 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1344:8
+1344 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1344:10
+1344 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1344:14
+1344 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1349:0
+1349 | }
+     | ^
+error: expected `}`
+- error_stresstest:1353:11
+1353 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1353:11
+1353 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1353:15
+1353 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1357:3
+1357 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1357:8
+1357 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1357:10
+1357 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1357:14
+1357 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1362:0
+1362 | }
+     | ^
+error: expected `}`
+- error_stresstest:1366:11
+1366 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1366:11
+1366 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1366:15
+1366 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1370:3
+1370 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1370:8
+1370 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1370:10
+1370 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1370:14
+1370 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1375:0
+1375 | }
+     | ^
+error: expected `}`
+- error_stresstest:1379:11
+1379 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1379:11
+1379 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1379:15
+1379 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1383:3
+1383 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1383:8
+1383 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1383:10
+1383 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1383:14
+1383 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1388:0
+1388 | }
+     | ^
+error: expected `}`
+- error_stresstest:1392:11
+1392 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1392:11
+1392 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1392:15
+1392 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1396:3
+1396 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1396:8
+1396 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1396:10
+1396 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1396:14
+1396 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1401:0
+1401 | }
+     | ^
+error: expected `}`
+- error_stresstest:1405:11
+1405 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1405:11
+1405 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1405:15
+1405 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1409:3
+1409 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1409:8
+1409 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1409:10
+1409 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1409:14
+1409 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1414:0
+1414 | }
+     | ^
+error: expected `}`
+- error_stresstest:1418:11
+1418 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1418:11
+1418 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1418:15
+1418 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1422:3
+1422 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1422:8
+1422 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1422:10
+1422 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1422:14
+1422 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1427:0
+1427 | }
+     | ^
+error: expected `}`
+- error_stresstest:1431:11
+1431 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1431:11
+1431 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1431:15
+1431 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1435:3
+1435 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1435:8
+1435 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1435:10
+1435 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1435:14
+1435 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1440:0
+1440 | }
+     | ^
+error: expected `}`
+- error_stresstest:1444:11
+1444 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1444:11
+1444 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1444:15
+1444 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1448:3
+1448 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1448:8
+1448 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1448:10
+1448 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1448:14
+1448 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1453:0
+1453 | }
+     | ^
+error: expected `}`
+- error_stresstest:1457:11
+1457 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1457:11
+1457 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1457:15
+1457 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1461:3
+1461 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1461:8
+1461 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1461:10
+1461 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1461:14
+1461 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1466:0
+1466 | }
+     | ^
+error: expected `}`
+- error_stresstest:1470:11
+1470 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1470:11
+1470 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1470:15
+1470 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1474:3
+1474 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1474:8
+1474 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1474:10
+1474 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1474:14
+1474 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1479:0
+1479 | }
+     | ^
+error: expected `}`
+- error_stresstest:1483:11
+1483 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1483:11
+1483 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1483:15
+1483 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1487:3
+1487 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1487:8
+1487 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1487:10
+1487 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1487:14
+1487 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1492:0
+1492 | }
+     | ^
+error: expected `}`
+- error_stresstest:1496:11
+1496 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1496:11
+1496 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1496:15
+1496 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1500:3
+1500 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1500:8
+1500 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1500:10
+1500 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1500:14
+1500 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1505:0
+1505 | }
+     | ^
+error: expected `}`
+- error_stresstest:1509:11
+1509 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1509:11
+1509 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1509:15
+1509 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1513:3
+1513 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1513:8
+1513 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1513:10
+1513 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1513:14
+1513 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1518:0
+1518 | }
+     | ^
+error: expected `}`
+- error_stresstest:1522:11
+1522 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1522:11
+1522 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1522:15
+1522 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1526:3
+1526 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1526:8
+1526 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1526:10
+1526 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1526:14
+1526 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1531:0
+1531 | }
+     | ^
+error: expected `}`
+- error_stresstest:1535:11
+1535 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1535:11
+1535 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1535:15
+1535 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1539:3
+1539 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1539:8
+1539 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1539:10
+1539 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1539:14
+1539 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1544:0
+1544 | }
+     | ^
+error: expected `}`
+- error_stresstest:1548:11
+1548 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1548:11
+1548 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1548:15
+1548 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1552:3
+1552 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1552:8
+1552 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1552:10
+1552 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1552:14
+1552 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1557:0
+1557 | }
+     | ^
+error: expected `}`
+- error_stresstest:1561:11
+1561 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1561:11
+1561 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1561:15
+1561 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1565:3
+1565 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1565:8
+1565 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1565:10
+1565 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1565:14
+1565 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1570:0
+1570 | }
+     | ^
+error: expected `}`
+- error_stresstest:1574:11
+1574 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1574:11
+1574 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1574:15
+1574 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1578:3
+1578 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1578:8
+1578 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1578:10
+1578 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1578:14
+1578 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1583:0
+1583 | }
+     | ^
+error: expected `}`
+- error_stresstest:1587:11
+1587 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1587:11
+1587 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1587:15
+1587 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1591:3
+1591 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1591:8
+1591 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1591:10
+1591 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1591:14
+1591 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1596:0
+1596 | }
+     | ^
+error: expected `}`
+- error_stresstest:1600:11
+1600 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1600:11
+1600 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1600:15
+1600 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1604:3
+1604 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1604:8
+1604 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1604:10
+1604 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1604:14
+1604 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1609:0
+1609 | }
+     | ^
+error: expected `}`
+- error_stresstest:1613:11
+1613 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1613:11
+1613 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1613:15
+1613 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1617:3
+1617 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1617:8
+1617 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1617:10
+1617 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1617:14
+1617 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1622:0
+1622 | }
+     | ^
+error: expected `}`
+- error_stresstest:1626:11
+1626 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1626:11
+1626 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1626:15
+1626 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1630:3
+1630 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1630:8
+1630 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1630:10
+1630 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1630:14
+1630 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1635:0
+1635 | }
+     | ^
+error: expected `}`
+- error_stresstest:1639:11
+1639 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1639:11
+1639 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1639:15
+1639 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1643:3
+1643 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1643:8
+1643 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1643:10
+1643 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1643:14
+1643 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1648:0
+1648 | }
+     | ^
+error: expected `}`
+- error_stresstest:1652:11
+1652 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1652:11
+1652 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1652:15
+1652 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1656:3
+1656 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1656:8
+1656 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1656:10
+1656 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1656:14
+1656 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1661:0
+1661 | }
+     | ^
+error: expected `}`
+- error_stresstest:1665:11
+1665 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1665:11
+1665 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1665:15
+1665 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1669:3
+1669 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1669:8
+1669 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1669:10
+1669 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1669:14
+1669 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1674:0
+1674 | }
+     | ^
+error: expected `}`
+- error_stresstest:1678:11
+1678 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1678:11
+1678 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1678:15
+1678 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1682:3
+1682 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1682:8
+1682 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1682:10
+1682 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1682:14
+1682 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1687:0
+1687 | }
+     | ^
+error: expected `}`
+- error_stresstest:1691:11
+1691 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1691:11
+1691 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1691:15
+1691 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1695:3
+1695 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1695:8
+1695 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1695:10
+1695 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1695:14
+1695 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1700:0
+1700 | }
+     | ^
+error: expected `}`
+- error_stresstest:1704:11
+1704 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1704:11
+1704 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1704:15
+1704 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1708:3
+1708 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1708:8
+1708 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1708:10
+1708 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1708:14
+1708 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1713:0
+1713 | }
+     | ^
+error: expected `}`
+- error_stresstest:1717:11
+1717 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1717:11
+1717 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1717:15
+1717 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1721:3
+1721 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1721:8
+1721 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1721:10
+1721 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1721:14
+1721 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1726:0
+1726 | }
+     | ^
+error: expected `}`
+- error_stresstest:1730:11
+1730 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1730:11
+1730 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1730:15
+1730 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1734:3
+1734 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1734:8
+1734 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1734:10
+1734 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1734:14
+1734 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1739:0
+1739 | }
+     | ^
+error: expected `}`
+- error_stresstest:1743:11
+1743 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1743:11
+1743 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1743:15
+1743 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1747:3
+1747 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1747:8
+1747 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1747:10
+1747 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1747:14
+1747 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1752:0
+1752 | }
+     | ^
+error: expected `}`
+- error_stresstest:1756:11
+1756 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1756:11
+1756 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1756:15
+1756 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1760:3
+1760 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1760:8
+1760 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1760:10
+1760 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1760:14
+1760 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1765:0
+1765 | }
+     | ^
+error: expected `}`
+- error_stresstest:1769:11
+1769 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1769:11
+1769 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1769:15
+1769 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1773:3
+1773 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1773:8
+1773 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1773:10
+1773 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1773:14
+1773 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1778:0
+1778 | }
+     | ^
+error: expected `}`
+- error_stresstest:1782:11
+1782 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1782:11
+1782 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1782:15
+1782 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1786:3
+1786 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1786:8
+1786 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1786:10
+1786 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1786:14
+1786 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1791:0
+1791 | }
+     | ^
+error: expected `}`
+- error_stresstest:1795:11
+1795 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1795:11
+1795 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1795:15
+1795 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1799:3
+1799 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1799:8
+1799 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1799:10
+1799 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1799:14
+1799 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1804:0
+1804 | }
+     | ^
+error: expected `}`
+- error_stresstest:1808:11
+1808 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1808:11
+1808 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1808:15
+1808 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1812:3
+1812 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1812:8
+1812 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1812:10
+1812 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1812:14
+1812 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1817:0
+1817 | }
+     | ^
+error: expected `}`
+- error_stresstest:1821:11
+1821 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1821:11
+1821 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1821:15
+1821 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1825:3
+1825 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1825:8
+1825 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1825:10
+1825 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1825:14
+1825 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1830:0
+1830 | }
+     | ^
+error: expected `}`
+- error_stresstest:1834:11
+1834 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1834:11
+1834 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1834:15
+1834 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1838:3
+1838 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1838:8
+1838 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1838:10
+1838 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1838:14
+1838 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1843:0
+1843 | }
+     | ^
+error: expected `}`
+- error_stresstest:1847:11
+1847 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1847:11
+1847 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1847:15
+1847 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1851:3
+1851 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1851:8
+1851 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1851:10
+1851 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1851:14
+1851 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1856:0
+1856 | }
+     | ^
+error: expected `}`
+- error_stresstest:1860:11
+1860 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1860:11
+1860 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1860:15
+1860 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1864:3
+1864 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1864:8
+1864 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1864:10
+1864 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1864:14
+1864 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1869:0
+1869 | }
+     | ^
+error: expected `}`
+- error_stresstest:1873:11
+1873 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1873:11
+1873 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1873:15
+1873 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1877:3
+1877 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1877:8
+1877 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1877:10
+1877 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1877:14
+1877 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1882:0
+1882 | }
+     | ^
+error: expected `}`
+- error_stresstest:1886:11
+1886 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1886:11
+1886 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1886:15
+1886 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1890:3
+1890 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1890:8
+1890 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1890:10
+1890 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1890:14
+1890 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1895:0
+1895 | }
+     | ^
+error: expected `}`
+- error_stresstest:1899:11
+1899 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1899:11
+1899 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1899:15
+1899 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1903:3
+1903 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1903:8
+1903 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1903:10
+1903 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1903:14
+1903 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1908:0
+1908 | }
+     | ^
+error: expected `}`
+- error_stresstest:1912:11
+1912 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1912:11
+1912 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1912:15
+1912 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1916:3
+1916 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1916:8
+1916 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1916:10
+1916 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1916:14
+1916 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1921:0
+1921 | }
+     | ^
+error: expected `}`
+- error_stresstest:1925:11
+1925 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1925:11
+1925 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1925:15
+1925 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1929:3
+1929 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1929:8
+1929 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1929:10
+1929 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1929:14
+1929 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1934:0
+1934 | }
+     | ^
+error: expected `}`
+- error_stresstest:1938:11
+1938 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1938:11
+1938 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1938:15
+1938 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1942:3
+1942 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1942:8
+1942 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1942:10
+1942 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1942:14
+1942 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1947:0
+1947 | }
+     | ^
+error: expected `}`
+- error_stresstest:1951:11
+1951 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1951:11
+1951 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1951:15
+1951 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1955:3
+1955 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1955:8
+1955 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1955:10
+1955 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1955:14
+1955 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1960:0
+1960 | }
+     | ^
+error: expected `}`
+- error_stresstest:1964:11
+1964 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1964:11
+1964 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1964:15
+1964 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1968:3
+1968 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1968:8
+1968 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1968:10
+1968 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1968:14
+1968 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1973:0
+1973 | }
+     | ^
+error: expected `}`
+- error_stresstest:1977:11
+1977 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1977:11
+1977 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1977:15
+1977 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1981:3
+1981 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1981:8
+1981 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1981:10
+1981 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1981:14
+1981 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1986:0
+1986 | }
+     | ^
+error: expected `}`
+- error_stresstest:1990:11
+1990 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:1990:11
+1990 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:1990:15
+1990 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:1994:3
+1994 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:1994:8
+1994 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:1994:10
+1994 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:1994:14
+1994 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:1999:0
+1999 | }
+     | ^
+error: expected `}`
+- error_stresstest:2003:11
+2003 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2003:11
+2003 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2003:15
+2003 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2007:3
+2007 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2007:8
+2007 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2007:10
+2007 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2007:14
+2007 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2012:0
+2012 | }
+     | ^
+error: expected `}`
+- error_stresstest:2016:11
+2016 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2016:11
+2016 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2016:15
+2016 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2020:3
+2020 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2020:8
+2020 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2020:10
+2020 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2020:14
+2020 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2025:0
+2025 | }
+     | ^
+error: expected `}`
+- error_stresstest:2029:11
+2029 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2029:11
+2029 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2029:15
+2029 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2033:3
+2033 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2033:8
+2033 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2033:10
+2033 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2033:14
+2033 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2038:0
+2038 | }
+     | ^
+error: expected `}`
+- error_stresstest:2042:11
+2042 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2042:11
+2042 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2042:15
+2042 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2046:3
+2046 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2046:8
+2046 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2046:10
+2046 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2046:14
+2046 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2051:0
+2051 | }
+     | ^
+error: expected `}`
+- error_stresstest:2055:11
+2055 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2055:11
+2055 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2055:15
+2055 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2059:3
+2059 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2059:8
+2059 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2059:10
+2059 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2059:14
+2059 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2064:0
+2064 | }
+     | ^
+error: expected `}`
+- error_stresstest:2068:11
+2068 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2068:11
+2068 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2068:15
+2068 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2072:3
+2072 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2072:8
+2072 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2072:10
+2072 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2072:14
+2072 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2077:0
+2077 | }
+     | ^
+error: expected `}`
+- error_stresstest:2081:11
+2081 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2081:11
+2081 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2081:15
+2081 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2085:3
+2085 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2085:8
+2085 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2085:10
+2085 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2085:14
+2085 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2090:0
+2090 | }
+     | ^
+error: expected `}`
+- error_stresstest:2094:11
+2094 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2094:11
+2094 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2094:15
+2094 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2098:3
+2098 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2098:8
+2098 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2098:10
+2098 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2098:14
+2098 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2103:0
+2103 | }
+     | ^
+error: expected `}`
+- error_stresstest:2107:11
+2107 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2107:11
+2107 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2107:15
+2107 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2111:3
+2111 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2111:8
+2111 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2111:10
+2111 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2111:14
+2111 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2116:0
+2116 | }
+     | ^
+error: expected `}`
+- error_stresstest:2120:11
+2120 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2120:11
+2120 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2120:15
+2120 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2124:3
+2124 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2124:8
+2124 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2124:10
+2124 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2124:14
+2124 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2129:0
+2129 | }
+     | ^
+error: expected `}`
+- error_stresstest:2133:11
+2133 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2133:11
+2133 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2133:15
+2133 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2137:3
+2137 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2137:8
+2137 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2137:10
+2137 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2137:14
+2137 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2142:0
+2142 | }
+     | ^
+error: expected `}`
+- error_stresstest:2146:11
+2146 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2146:11
+2146 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2146:15
+2146 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2150:3
+2150 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2150:8
+2150 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2150:10
+2150 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2150:14
+2150 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2155:0
+2155 | }
+     | ^
+error: expected `}`
+- error_stresstest:2159:11
+2159 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2159:11
+2159 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2159:15
+2159 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2163:3
+2163 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2163:8
+2163 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2163:10
+2163 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2163:14
+2163 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2168:0
+2168 | }
+     | ^
+error: expected `}`
+- error_stresstest:2172:11
+2172 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2172:11
+2172 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2172:15
+2172 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2176:3
+2176 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2176:8
+2176 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2176:10
+2176 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2176:14
+2176 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2181:0
+2181 | }
+     | ^
+error: expected `}`
+- error_stresstest:2185:11
+2185 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2185:11
+2185 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2185:15
+2185 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2189:3
+2189 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2189:8
+2189 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2189:10
+2189 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2189:14
+2189 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2194:0
+2194 | }
+     | ^
+error: expected `}`
+- error_stresstest:2198:11
+2198 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2198:11
+2198 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2198:15
+2198 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2202:3
+2202 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2202:8
+2202 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2202:10
+2202 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2202:14
+2202 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2207:0
+2207 | }
+     | ^
+error: expected `}`
+- error_stresstest:2211:11
+2211 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2211:11
+2211 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2211:15
+2211 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2215:3
+2215 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2215:8
+2215 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2215:10
+2215 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2215:14
+2215 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2220:0
+2220 | }
+     | ^
+error: expected `}`
+- error_stresstest:2224:11
+2224 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2224:11
+2224 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2224:15
+2224 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2228:3
+2228 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2228:8
+2228 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2228:10
+2228 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2228:14
+2228 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2233:0
+2233 | }
+     | ^
+error: expected `}`
+- error_stresstest:2237:11
+2237 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2237:11
+2237 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2237:15
+2237 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2241:3
+2241 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2241:8
+2241 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2241:10
+2241 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2241:14
+2241 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2246:0
+2246 | }
+     | ^
+error: expected `}`
+- error_stresstest:2250:11
+2250 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2250:11
+2250 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2250:15
+2250 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2254:3
+2254 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2254:8
+2254 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2254:10
+2254 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2254:14
+2254 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2259:0
+2259 | }
+     | ^
+error: expected `}`
+- error_stresstest:2263:11
+2263 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2263:11
+2263 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2263:15
+2263 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2267:3
+2267 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2267:8
+2267 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2267:10
+2267 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2267:14
+2267 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2272:0
+2272 | }
+     | ^
+error: expected `}`
+- error_stresstest:2276:11
+2276 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2276:11
+2276 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2276:15
+2276 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2280:3
+2280 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2280:8
+2280 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2280:10
+2280 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2280:14
+2280 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2285:0
+2285 | }
+     | ^
+error: expected `}`
+- error_stresstest:2289:11
+2289 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2289:11
+2289 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2289:15
+2289 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2293:3
+2293 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2293:8
+2293 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2293:10
+2293 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2293:14
+2293 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2298:0
+2298 | }
+     | ^
+error: expected `}`
+- error_stresstest:2302:11
+2302 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2302:11
+2302 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2302:15
+2302 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2306:3
+2306 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2306:8
+2306 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2306:10
+2306 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2306:14
+2306 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2311:0
+2311 | }
+     | ^
+error: expected `}`
+- error_stresstest:2315:11
+2315 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2315:11
+2315 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2315:15
+2315 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2319:3
+2319 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2319:8
+2319 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2319:10
+2319 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2319:14
+2319 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2324:0
+2324 | }
+     | ^
+error: expected `}`
+- error_stresstest:2328:11
+2328 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2328:11
+2328 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2328:15
+2328 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2332:3
+2332 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2332:8
+2332 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2332:10
+2332 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2332:14
+2332 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2337:0
+2337 | }
+     | ^
+error: expected `}`
+- error_stresstest:2341:11
+2341 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2341:11
+2341 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2341:15
+2341 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2345:3
+2345 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2345:8
+2345 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2345:10
+2345 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2345:14
+2345 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2350:0
+2350 | }
+     | ^
+error: expected `}`
+- error_stresstest:2354:11
+2354 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2354:11
+2354 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2354:15
+2354 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2358:3
+2358 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2358:8
+2358 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2358:10
+2358 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2358:14
+2358 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2363:0
+2363 | }
+     | ^
+error: expected `}`
+- error_stresstest:2367:11
+2367 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2367:11
+2367 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2367:15
+2367 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2371:3
+2371 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2371:8
+2371 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2371:10
+2371 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2371:14
+2371 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2376:0
+2376 | }
+     | ^
+error: expected `}`
+- error_stresstest:2380:11
+2380 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2380:11
+2380 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2380:15
+2380 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2384:3
+2384 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2384:8
+2384 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2384:10
+2384 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2384:14
+2384 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2389:0
+2389 | }
+     | ^
+error: expected `}`
+- error_stresstest:2393:11
+2393 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2393:11
+2393 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2393:15
+2393 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2397:3
+2397 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2397:8
+2397 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2397:10
+2397 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2397:14
+2397 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2402:0
+2402 | }
+     | ^
+error: expected `}`
+- error_stresstest:2406:11
+2406 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2406:11
+2406 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2406:15
+2406 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2410:3
+2410 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2410:8
+2410 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2410:10
+2410 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2410:14
+2410 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2415:0
+2415 | }
+     | ^
+error: expected `}`
+- error_stresstest:2419:11
+2419 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2419:11
+2419 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2419:15
+2419 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2423:3
+2423 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2423:8
+2423 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2423:10
+2423 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2423:14
+2423 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2428:0
+2428 | }
+     | ^
+error: expected `}`
+- error_stresstest:2432:11
+2432 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2432:11
+2432 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2432:15
+2432 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2436:3
+2436 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2436:8
+2436 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2436:10
+2436 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2436:14
+2436 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2441:0
+2441 | }
+     | ^
+error: expected `}`
+- error_stresstest:2445:11
+2445 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2445:11
+2445 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2445:15
+2445 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2449:3
+2449 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2449:8
+2449 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2449:10
+2449 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2449:14
+2449 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2454:0
+2454 | }
+     | ^
+error: expected `}`
+- error_stresstest:2458:11
+2458 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2458:11
+2458 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2458:15
+2458 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2462:3
+2462 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2462:8
+2462 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2462:10
+2462 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2462:14
+2462 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2467:0
+2467 | }
+     | ^
+error: expected `}`
+- error_stresstest:2471:11
+2471 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2471:11
+2471 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2471:15
+2471 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2475:3
+2475 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2475:8
+2475 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2475:10
+2475 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2475:14
+2475 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2480:0
+2480 | }
+     | ^
+error: expected `}`
+- error_stresstest:2484:11
+2484 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2484:11
+2484 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2484:15
+2484 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2488:3
+2488 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2488:8
+2488 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2488:10
+2488 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2488:14
+2488 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2493:0
+2493 | }
+     | ^
+error: expected `}`
+- error_stresstest:2497:11
+2497 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2497:11
+2497 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2497:15
+2497 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2501:3
+2501 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2501:8
+2501 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2501:10
+2501 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2501:14
+2501 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2506:0
+2506 | }
+     | ^
+error: expected `}`
+- error_stresstest:2510:11
+2510 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2510:11
+2510 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2510:15
+2510 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2514:3
+2514 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2514:8
+2514 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2514:10
+2514 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2514:14
+2514 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2519:0
+2519 | }
+     | ^
+error: expected `}`
+- error_stresstest:2523:11
+2523 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2523:11
+2523 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2523:15
+2523 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2527:3
+2527 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2527:8
+2527 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2527:10
+2527 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2527:14
+2527 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2532:0
+2532 | }
+     | ^
+error: expected `}`
+- error_stresstest:2536:11
+2536 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2536:11
+2536 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2536:15
+2536 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2540:3
+2540 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2540:8
+2540 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2540:10
+2540 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2540:14
+2540 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2545:0
+2545 | }
+     | ^
+error: expected `}`
+- error_stresstest:2549:11
+2549 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2549:11
+2549 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2549:15
+2549 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2553:3
+2553 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2553:8
+2553 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2553:10
+2553 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2553:14
+2553 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2558:0
+2558 | }
+     | ^
+error: expected `}`
+- error_stresstest:2562:11
+2562 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2562:11
+2562 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2562:15
+2562 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2566:3
+2566 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2566:8
+2566 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2566:10
+2566 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2566:14
+2566 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2571:0
+2571 | }
+     | ^
+error: expected `}`
+- error_stresstest:2575:11
+2575 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2575:11
+2575 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2575:15
+2575 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2579:3
+2579 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2579:8
+2579 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2579:10
+2579 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2579:14
+2579 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2584:0
+2584 | }
+     | ^
+error: expected `}`
+- error_stresstest:2588:11
+2588 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2588:11
+2588 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2588:15
+2588 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2592:3
+2592 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2592:8
+2592 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2592:10
+2592 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2592:14
+2592 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2597:0
+2597 | }
+     | ^
+error: expected `}`
+- error_stresstest:2601:11
+2601 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2601:11
+2601 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2601:15
+2601 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2605:3
+2605 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2605:8
+2605 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2605:10
+2605 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2605:14
+2605 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2610:0
+2610 | }
+     | ^
+error: expected `}`
+- error_stresstest:2614:11
+2614 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2614:11
+2614 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2614:15
+2614 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2618:3
+2618 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2618:8
+2618 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2618:10
+2618 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2618:14
+2618 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2623:0
+2623 | }
+     | ^
+error: expected `}`
+- error_stresstest:2627:11
+2627 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2627:11
+2627 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2627:15
+2627 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2631:3
+2631 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2631:8
+2631 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2631:10
+2631 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2631:14
+2631 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2636:0
+2636 | }
+     | ^
+error: expected `}`
+- error_stresstest:2640:11
+2640 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2640:11
+2640 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2640:15
+2640 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2644:3
+2644 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2644:8
+2644 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2644:10
+2644 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2644:14
+2644 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2649:0
+2649 | }
+     | ^
+error: expected `}`
+- error_stresstest:2653:11
+2653 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2653:11
+2653 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2653:15
+2653 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2657:3
+2657 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2657:8
+2657 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2657:10
+2657 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2657:14
+2657 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2662:0
+2662 | }
+     | ^
+error: expected `}`
+- error_stresstest:2666:11
+2666 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2666:11
+2666 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2666:15
+2666 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2670:3
+2670 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2670:8
+2670 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2670:10
+2670 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2670:14
+2670 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2675:0
+2675 | }
+     | ^
+error: expected `}`
+- error_stresstest:2679:11
+2679 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2679:11
+2679 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2679:15
+2679 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2683:3
+2683 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2683:8
+2683 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2683:10
+2683 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2683:14
+2683 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2688:0
+2688 | }
+     | ^
+error: expected `}`
+- error_stresstest:2692:11
+2692 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2692:11
+2692 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2692:15
+2692 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2696:3
+2696 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2696:8
+2696 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2696:10
+2696 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2696:14
+2696 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2701:0
+2701 | }
+     | ^
+error: expected `}`
+- error_stresstest:2705:11
+2705 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2705:11
+2705 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2705:15
+2705 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2709:3
+2709 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2709:8
+2709 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2709:10
+2709 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2709:14
+2709 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2714:0
+2714 | }
+     | ^
+error: expected `}`
+- error_stresstest:2718:11
+2718 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2718:11
+2718 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2718:15
+2718 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2722:3
+2722 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2722:8
+2722 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2722:10
+2722 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2722:14
+2722 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2727:0
+2727 | }
+     | ^
+error: expected `}`
+- error_stresstest:2731:11
+2731 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2731:11
+2731 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2731:15
+2731 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2735:3
+2735 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2735:8
+2735 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2735:10
+2735 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2735:14
+2735 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2740:0
+2740 | }
+     | ^
+error: expected `}`
+- error_stresstest:2744:11
+2744 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2744:11
+2744 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2744:15
+2744 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2748:3
+2748 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2748:8
+2748 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2748:10
+2748 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2748:14
+2748 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2753:0
+2753 | }
+     | ^
+error: expected `}`
+- error_stresstest:2757:11
+2757 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2757:11
+2757 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2757:15
+2757 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2761:3
+2761 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2761:8
+2761 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2761:10
+2761 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2761:14
+2761 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2766:0
+2766 | }
+     | ^
+error: expected `}`
+- error_stresstest:2770:11
+2770 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2770:11
+2770 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2770:15
+2770 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2774:3
+2774 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2774:8
+2774 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2774:10
+2774 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2774:14
+2774 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2779:0
+2779 | }
+     | ^
+error: expected `}`
+- error_stresstest:2783:11
+2783 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2783:11
+2783 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2783:15
+2783 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2787:3
+2787 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2787:8
+2787 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2787:10
+2787 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2787:14
+2787 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2792:0
+2792 | }
+     | ^
+error: expected `}`
+- error_stresstest:2796:11
+2796 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2796:11
+2796 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2796:15
+2796 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2800:3
+2800 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2800:8
+2800 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2800:10
+2800 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2800:14
+2800 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2805:0
+2805 | }
+     | ^
+error: expected `}`
+- error_stresstest:2809:11
+2809 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2809:11
+2809 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2809:15
+2809 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2813:3
+2813 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2813:8
+2813 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2813:10
+2813 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2813:14
+2813 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2818:0
+2818 | }
+     | ^
+error: expected `}`
+- error_stresstest:2822:11
+2822 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2822:11
+2822 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2822:15
+2822 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2826:3
+2826 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2826:8
+2826 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2826:10
+2826 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2826:14
+2826 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2831:0
+2831 | }
+     | ^
+error: expected `}`
+- error_stresstest:2835:11
+2835 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2835:11
+2835 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2835:15
+2835 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2839:3
+2839 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2839:8
+2839 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2839:10
+2839 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2839:14
+2839 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2844:0
+2844 | }
+     | ^
+error: expected `}`
+- error_stresstest:2848:11
+2848 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2848:11
+2848 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2848:15
+2848 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2852:3
+2852 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2852:8
+2852 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2852:10
+2852 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2852:14
+2852 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2857:0
+2857 | }
+     | ^
+error: expected `}`
+- error_stresstest:2861:11
+2861 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2861:11
+2861 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2861:15
+2861 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2865:3
+2865 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2865:8
+2865 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2865:10
+2865 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2865:14
+2865 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2870:0
+2870 | }
+     | ^
+error: expected `}`
+- error_stresstest:2874:11
+2874 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2874:11
+2874 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2874:15
+2874 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2878:3
+2878 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2878:8
+2878 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2878:10
+2878 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2878:14
+2878 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2883:0
+2883 | }
+     | ^
+error: expected `}`
+- error_stresstest:2887:11
+2887 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2887:11
+2887 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2887:15
+2887 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2891:3
+2891 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2891:8
+2891 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2891:10
+2891 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2891:14
+2891 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2896:0
+2896 | }
+     | ^
+error: expected `}`
+- error_stresstest:2900:11
+2900 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2900:11
+2900 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2900:15
+2900 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2904:3
+2904 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2904:8
+2904 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2904:10
+2904 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2904:14
+2904 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2909:0
+2909 | }
+     | ^
+error: expected `}`
+- error_stresstest:2913:11
+2913 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2913:11
+2913 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2913:15
+2913 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2917:3
+2917 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2917:8
+2917 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2917:10
+2917 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2917:14
+2917 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2922:0
+2922 | }
+     | ^
+error: expected `}`
+- error_stresstest:2926:11
+2926 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2926:11
+2926 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2926:15
+2926 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2930:3
+2930 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2930:8
+2930 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2930:10
+2930 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2930:14
+2930 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2935:0
+2935 | }
+     | ^
+error: expected `}`
+- error_stresstest:2939:11
+2939 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2939:11
+2939 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2939:15
+2939 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2943:3
+2943 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2943:8
+2943 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2943:10
+2943 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2943:14
+2943 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2948:0
+2948 | }
+     | ^
+error: expected `}`
+- error_stresstest:2952:11
+2952 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2952:11
+2952 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2952:15
+2952 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2956:3
+2956 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2956:8
+2956 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2956:10
+2956 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2956:14
+2956 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2961:0
+2961 | }
+     | ^
+error: expected `}`
+- error_stresstest:2965:11
+2965 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2965:11
+2965 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2965:15
+2965 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2969:3
+2969 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2969:8
+2969 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2969:10
+2969 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2969:14
+2969 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2974:0
+2974 | }
+     | ^
+error: expected `}`
+- error_stresstest:2978:11
+2978 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2978:11
+2978 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2978:15
+2978 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2982:3
+2982 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2982:8
+2982 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2982:10
+2982 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2982:14
+2982 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:2987:0
+2987 | }
+     | ^
+error: expected `}`
+- error_stresstest:2991:11
+2991 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:2991:11
+2991 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:2991:15
+2991 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:2995:3
+2995 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:2995:8
+2995 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:2995:10
+2995 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:2995:14
+2995 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3000:0
+3000 | }
+     | ^
+error: expected `}`
+- error_stresstest:3004:11
+3004 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3004:11
+3004 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3004:15
+3004 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3008:3
+3008 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3008:8
+3008 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3008:10
+3008 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3008:14
+3008 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3013:0
+3013 | }
+     | ^
+error: expected `}`
+- error_stresstest:3017:11
+3017 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3017:11
+3017 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3017:15
+3017 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3021:3
+3021 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3021:8
+3021 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3021:10
+3021 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3021:14
+3021 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3026:0
+3026 | }
+     | ^
+error: expected `}`
+- error_stresstest:3030:11
+3030 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3030:11
+3030 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3030:15
+3030 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3034:3
+3034 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3034:8
+3034 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3034:10
+3034 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3034:14
+3034 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3039:0
+3039 | }
+     | ^
+error: expected `}`
+- error_stresstest:3043:11
+3043 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3043:11
+3043 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3043:15
+3043 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3047:3
+3047 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3047:8
+3047 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3047:10
+3047 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3047:14
+3047 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3052:0
+3052 | }
+     | ^
+error: expected `}`
+- error_stresstest:3056:11
+3056 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3056:11
+3056 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3056:15
+3056 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3060:3
+3060 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3060:8
+3060 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3060:10
+3060 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3060:14
+3060 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3065:0
+3065 | }
+     | ^
+error: expected `}`
+- error_stresstest:3069:11
+3069 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3069:11
+3069 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3069:15
+3069 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3073:3
+3073 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3073:8
+3073 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3073:10
+3073 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3073:14
+3073 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3078:0
+3078 | }
+     | ^
+error: expected `}`
+- error_stresstest:3082:11
+3082 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3082:11
+3082 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3082:15
+3082 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3086:3
+3086 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3086:8
+3086 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3086:10
+3086 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3086:14
+3086 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3091:0
+3091 | }
+     | ^
+error: expected `}`
+- error_stresstest:3095:11
+3095 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3095:11
+3095 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3095:15
+3095 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3099:3
+3099 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3099:8
+3099 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3099:10
+3099 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3099:14
+3099 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3104:0
+3104 | }
+     | ^
+error: expected `}`
+- error_stresstest:3108:11
+3108 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3108:11
+3108 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3108:15
+3108 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3112:3
+3112 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3112:8
+3112 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3112:10
+3112 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3112:14
+3112 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3117:0
+3117 | }
+     | ^
+error: expected `}`
+- error_stresstest:3121:11
+3121 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3121:11
+3121 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3121:15
+3121 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3125:3
+3125 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3125:8
+3125 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3125:10
+3125 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3125:14
+3125 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3130:0
+3130 | }
+     | ^
+error: expected `}`
+- error_stresstest:3134:11
+3134 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3134:11
+3134 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3134:15
+3134 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3138:3
+3138 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3138:8
+3138 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3138:10
+3138 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3138:14
+3138 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3143:0
+3143 | }
+     | ^
+error: expected `}`
+- error_stresstest:3147:11
+3147 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3147:11
+3147 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3147:15
+3147 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3151:3
+3151 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3151:8
+3151 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3151:10
+3151 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3151:14
+3151 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3156:0
+3156 | }
+     | ^
+error: expected `}`
+- error_stresstest:3160:11
+3160 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3160:11
+3160 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3160:15
+3160 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3164:3
+3164 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3164:8
+3164 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3164:10
+3164 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3164:14
+3164 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3169:0
+3169 | }
+     | ^
+error: expected `}`
+- error_stresstest:3173:11
+3173 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3173:11
+3173 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3173:15
+3173 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3177:3
+3177 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3177:8
+3177 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3177:10
+3177 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3177:14
+3177 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3182:0
+3182 | }
+     | ^
+error: expected `}`
+- error_stresstest:3186:11
+3186 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3186:11
+3186 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3186:15
+3186 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3190:3
+3190 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3190:8
+3190 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3190:10
+3190 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3190:14
+3190 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3195:0
+3195 | }
+     | ^
+error: expected `}`
+- error_stresstest:3199:11
+3199 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3199:11
+3199 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3199:15
+3199 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3203:3
+3203 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3203:8
+3203 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3203:10
+3203 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3203:14
+3203 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3208:0
+3208 | }
+     | ^
+error: expected `}`
+- error_stresstest:3212:11
+3212 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3212:11
+3212 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3212:15
+3212 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3216:3
+3216 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3216:8
+3216 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3216:10
+3216 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3216:14
+3216 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3221:0
+3221 | }
+     | ^
+error: expected `}`
+- error_stresstest:3225:11
+3225 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3225:11
+3225 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3225:15
+3225 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3229:3
+3229 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3229:8
+3229 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3229:10
+3229 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3229:14
+3229 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3234:0
+3234 | }
+     | ^
+error: expected `}`
+- error_stresstest:3238:11
+3238 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3238:11
+3238 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3238:15
+3238 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3242:3
+3242 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3242:8
+3242 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3242:10
+3242 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3242:14
+3242 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3247:0
+3247 | }
+     | ^
+error: expected `}`
+- error_stresstest:3251:11
+3251 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3251:11
+3251 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3251:15
+3251 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3255:3
+3255 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3255:8
+3255 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3255:10
+3255 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3255:14
+3255 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3260:0
+3260 | }
+     | ^
+error: expected `}`
+- error_stresstest:3264:11
+3264 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3264:11
+3264 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3264:15
+3264 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3268:3
+3268 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3268:8
+3268 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3268:10
+3268 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3268:14
+3268 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3273:0
+3273 | }
+     | ^
+error: expected `}`
+- error_stresstest:3277:11
+3277 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3277:11
+3277 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3277:15
+3277 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3281:3
+3281 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3281:8
+3281 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3281:10
+3281 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3281:14
+3281 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3286:0
+3286 | }
+     | ^
+error: expected `}`
+- error_stresstest:3290:11
+3290 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3290:11
+3290 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3290:15
+3290 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3294:3
+3294 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3294:8
+3294 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3294:10
+3294 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3294:14
+3294 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3299:0
+3299 | }
+     | ^
+error: expected `}`
+- error_stresstest:3303:11
+3303 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3303:11
+3303 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3303:15
+3303 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3307:3
+3307 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3307:8
+3307 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3307:10
+3307 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3307:14
+3307 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3312:0
+3312 | }
+     | ^
+error: expected `}`
+- error_stresstest:3316:11
+3316 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3316:11
+3316 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3316:15
+3316 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3320:3
+3320 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3320:8
+3320 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3320:10
+3320 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3320:14
+3320 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3325:0
+3325 | }
+     | ^
+error: expected `}`
+- error_stresstest:3329:11
+3329 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3329:11
+3329 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3329:15
+3329 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3333:3
+3333 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3333:8
+3333 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3333:10
+3333 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3333:14
+3333 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3338:0
+3338 | }
+     | ^
+error: expected `}`
+- error_stresstest:3342:11
+3342 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3342:11
+3342 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3342:15
+3342 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3346:3
+3346 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3346:8
+3346 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3346:10
+3346 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3346:14
+3346 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3351:0
+3351 | }
+     | ^
+error: expected `}`
+- error_stresstest:3355:11
+3355 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3355:11
+3355 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3355:15
+3355 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3359:3
+3359 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3359:8
+3359 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3359:10
+3359 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3359:14
+3359 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3364:0
+3364 | }
+     | ^
+error: expected `}`
+- error_stresstest:3368:11
+3368 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3368:11
+3368 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3368:15
+3368 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3372:3
+3372 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3372:8
+3372 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3372:10
+3372 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3372:14
+3372 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3377:0
+3377 | }
+     | ^
+error: expected `}`
+- error_stresstest:3381:11
+3381 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3381:11
+3381 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3381:15
+3381 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3385:3
+3385 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3385:8
+3385 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3385:10
+3385 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3385:14
+3385 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3390:0
+3390 | }
+     | ^
+error: expected `}`
+- error_stresstest:3394:11
+3394 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3394:11
+3394 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3394:15
+3394 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3398:3
+3398 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3398:8
+3398 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3398:10
+3398 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3398:14
+3398 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3403:0
+3403 | }
+     | ^
+error: expected `}`
+- error_stresstest:3407:11
+3407 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3407:11
+3407 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3407:15
+3407 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3411:3
+3411 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3411:8
+3411 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3411:10
+3411 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3411:14
+3411 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3416:0
+3416 | }
+     | ^
+error: expected `}`
+- error_stresstest:3420:11
+3420 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3420:11
+3420 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3420:15
+3420 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3424:3
+3424 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3424:8
+3424 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3424:10
+3424 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3424:14
+3424 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3429:0
+3429 | }
+     | ^
+error: expected `}`
+- error_stresstest:3433:11
+3433 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3433:11
+3433 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3433:15
+3433 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3437:3
+3437 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3437:8
+3437 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3437:10
+3437 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3437:14
+3437 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3442:0
+3442 | }
+     | ^
+error: expected `}`
+- error_stresstest:3446:11
+3446 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3446:11
+3446 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3446:15
+3446 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3450:3
+3450 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3450:8
+3450 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3450:10
+3450 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3450:14
+3450 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3455:0
+3455 | }
+     | ^
+error: expected `}`
+- error_stresstest:3459:11
+3459 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3459:11
+3459 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3459:15
+3459 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3463:3
+3463 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3463:8
+3463 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3463:10
+3463 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3463:14
+3463 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3468:0
+3468 | }
+     | ^
+error: expected `}`
+- error_stresstest:3472:11
+3472 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3472:11
+3472 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3472:15
+3472 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3476:3
+3476 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3476:8
+3476 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3476:10
+3476 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3476:14
+3476 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3481:0
+3481 | }
+     | ^
+error: expected `}`
+- error_stresstest:3485:11
+3485 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3485:11
+3485 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3485:15
+3485 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3489:3
+3489 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3489:8
+3489 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3489:10
+3489 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3489:14
+3489 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3494:0
+3494 | }
+     | ^
+error: expected `}`
+- error_stresstest:3498:11
+3498 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3498:11
+3498 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3498:15
+3498 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3502:3
+3502 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3502:8
+3502 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3502:10
+3502 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3502:14
+3502 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3507:0
+3507 | }
+     | ^
+error: expected `}`
+- error_stresstest:3511:11
+3511 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3511:11
+3511 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3511:15
+3511 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3515:3
+3515 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3515:8
+3515 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3515:10
+3515 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3515:14
+3515 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3520:0
+3520 | }
+     | ^
+error: expected `}`
+- error_stresstest:3524:11
+3524 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3524:11
+3524 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3524:15
+3524 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3528:3
+3528 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3528:8
+3528 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3528:10
+3528 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3528:14
+3528 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3533:0
+3533 | }
+     | ^
+error: expected `}`
+- error_stresstest:3537:11
+3537 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3537:11
+3537 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3537:15
+3537 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3541:3
+3541 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3541:8
+3541 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3541:10
+3541 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3541:14
+3541 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3546:0
+3546 | }
+     | ^
+error: expected `}`
+- error_stresstest:3550:11
+3550 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3550:11
+3550 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3550:15
+3550 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3554:3
+3554 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3554:8
+3554 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3554:10
+3554 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3554:14
+3554 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3559:0
+3559 | }
+     | ^
+error: expected `}`
+- error_stresstest:3563:11
+3563 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3563:11
+3563 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3563:15
+3563 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3567:3
+3567 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3567:8
+3567 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3567:10
+3567 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3567:14
+3567 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3572:0
+3572 | }
+     | ^
+error: expected `}`
+- error_stresstest:3576:11
+3576 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3576:11
+3576 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3576:15
+3576 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3580:3
+3580 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3580:8
+3580 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3580:10
+3580 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3580:14
+3580 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3585:0
+3585 | }
+     | ^
+error: expected `}`
+- error_stresstest:3589:11
+3589 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3589:11
+3589 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3589:15
+3589 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3593:3
+3593 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3593:8
+3593 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3593:10
+3593 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3593:14
+3593 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3598:0
+3598 | }
+     | ^
+error: expected `}`
+- error_stresstest:3602:11
+3602 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3602:11
+3602 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3602:15
+3602 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3606:3
+3606 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3606:8
+3606 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3606:10
+3606 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3606:14
+3606 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3611:0
+3611 | }
+     | ^
+error: expected `}`
+- error_stresstest:3615:11
+3615 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3615:11
+3615 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3615:15
+3615 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3619:3
+3619 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3619:8
+3619 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3619:10
+3619 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3619:14
+3619 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3624:0
+3624 | }
+     | ^
+error: expected `}`
+- error_stresstest:3628:11
+3628 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3628:11
+3628 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3628:15
+3628 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3632:3
+3632 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3632:8
+3632 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3632:10
+3632 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3632:14
+3632 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3637:0
+3637 | }
+     | ^
+error: expected `}`
+- error_stresstest:3641:11
+3641 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3641:11
+3641 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3641:15
+3641 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3645:3
+3645 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3645:8
+3645 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3645:10
+3645 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3645:14
+3645 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3650:0
+3650 | }
+     | ^
+error: expected `}`
+- error_stresstest:3654:11
+3654 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3654:11
+3654 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3654:15
+3654 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3658:3
+3658 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3658:8
+3658 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3658:10
+3658 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3658:14
+3658 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3663:0
+3663 | }
+     | ^
+error: expected `}`
+- error_stresstest:3667:11
+3667 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3667:11
+3667 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3667:15
+3667 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3671:3
+3671 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3671:8
+3671 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3671:10
+3671 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3671:14
+3671 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3676:0
+3676 | }
+     | ^
+error: expected `}`
+- error_stresstest:3680:11
+3680 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3680:11
+3680 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3680:15
+3680 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3684:3
+3684 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3684:8
+3684 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3684:10
+3684 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3684:14
+3684 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3689:0
+3689 | }
+     | ^
+error: expected `}`
+- error_stresstest:3693:11
+3693 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3693:11
+3693 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3693:15
+3693 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3697:3
+3697 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3697:8
+3697 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3697:10
+3697 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3697:14
+3697 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3702:0
+3702 | }
+     | ^
+error: expected `}`
+- error_stresstest:3706:11
+3706 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3706:11
+3706 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3706:15
+3706 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3710:3
+3710 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3710:8
+3710 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3710:10
+3710 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3710:14
+3710 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3715:0
+3715 | }
+     | ^
+error: expected `}`
+- error_stresstest:3719:11
+3719 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3719:11
+3719 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3719:15
+3719 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3723:3
+3723 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3723:8
+3723 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3723:10
+3723 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3723:14
+3723 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3728:0
+3728 | }
+     | ^
+error: expected `}`
+- error_stresstest:3732:11
+3732 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3732:11
+3732 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3732:15
+3732 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3736:3
+3736 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3736:8
+3736 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3736:10
+3736 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3736:14
+3736 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3741:0
+3741 | }
+     | ^
+error: expected `}`
+- error_stresstest:3745:11
+3745 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3745:11
+3745 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3745:15
+3745 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3749:3
+3749 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3749:8
+3749 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3749:10
+3749 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3749:14
+3749 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3754:0
+3754 | }
+     | ^
+error: expected `}`
+- error_stresstest:3758:11
+3758 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3758:11
+3758 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3758:15
+3758 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3762:3
+3762 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3762:8
+3762 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3762:10
+3762 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3762:14
+3762 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3767:0
+3767 | }
+     | ^
+error: expected `}`
+- error_stresstest:3771:11
+3771 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3771:11
+3771 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3771:15
+3771 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3775:3
+3775 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3775:8
+3775 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3775:10
+3775 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3775:14
+3775 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3780:0
+3780 | }
+     | ^
+error: expected `}`
+- error_stresstest:3784:11
+3784 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3784:11
+3784 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3784:15
+3784 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3788:3
+3788 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3788:8
+3788 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3788:10
+3788 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3788:14
+3788 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3793:0
+3793 | }
+     | ^
+error: expected `}`
+- error_stresstest:3797:11
+3797 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3797:11
+3797 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3797:15
+3797 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3801:3
+3801 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3801:8
+3801 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3801:10
+3801 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3801:14
+3801 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3806:0
+3806 | }
+     | ^
+error: expected `}`
+- error_stresstest:3810:11
+3810 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3810:11
+3810 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3810:15
+3810 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3814:3
+3814 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3814:8
+3814 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3814:10
+3814 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3814:14
+3814 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3819:0
+3819 | }
+     | ^
+error: expected `}`
+- error_stresstest:3823:11
+3823 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3823:11
+3823 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3823:15
+3823 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3827:3
+3827 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3827:8
+3827 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3827:10
+3827 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3827:14
+3827 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3832:0
+3832 | }
+     | ^
+error: expected `}`
+- error_stresstest:3836:11
+3836 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3836:11
+3836 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3836:15
+3836 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3840:3
+3840 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3840:8
+3840 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3840:10
+3840 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3840:14
+3840 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3845:0
+3845 | }
+     | ^
+error: expected `}`
+- error_stresstest:3849:11
+3849 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3849:11
+3849 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3849:15
+3849 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3853:3
+3853 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3853:8
+3853 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3853:10
+3853 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3853:14
+3853 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3858:0
+3858 | }
+     | ^
+error: expected `}`
+- error_stresstest:3862:11
+3862 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3862:11
+3862 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3862:15
+3862 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3866:3
+3866 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3866:8
+3866 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3866:10
+3866 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3866:14
+3866 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3871:0
+3871 | }
+     | ^
+error: expected `}`
+- error_stresstest:3875:11
+3875 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3875:11
+3875 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3875:15
+3875 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3879:3
+3879 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3879:8
+3879 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3879:10
+3879 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3879:14
+3879 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3884:0
+3884 | }
+     | ^
+error: expected `}`
+- error_stresstest:3888:11
+3888 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3888:11
+3888 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3888:15
+3888 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3892:3
+3892 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3892:8
+3892 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3892:10
+3892 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3892:14
+3892 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3897:0
+3897 | }
+     | ^
+error: expected `}`
+- error_stresstest:3901:11
+3901 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3901:11
+3901 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3901:15
+3901 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3905:3
+3905 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3905:8
+3905 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3905:10
+3905 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3905:14
+3905 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3910:0
+3910 | }
+     | ^
+error: expected `}`
+- error_stresstest:3914:11
+3914 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3914:11
+3914 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3914:15
+3914 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3918:3
+3918 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3918:8
+3918 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3918:10
+3918 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3918:14
+3918 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3923:0
+3923 | }
+     | ^
+error: expected `}`
+- error_stresstest:3927:11
+3927 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3927:11
+3927 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3927:15
+3927 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3931:3
+3931 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3931:8
+3931 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3931:10
+3931 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3931:14
+3931 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3936:0
+3936 | }
+     | ^
+error: expected `}`
+- error_stresstest:3940:11
+3940 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3940:11
+3940 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3940:15
+3940 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3944:3
+3944 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3944:8
+3944 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3944:10
+3944 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3944:14
+3944 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3949:0
+3949 | }
+     | ^
+error: expected `}`
+- error_stresstest:3953:11
+3953 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3953:11
+3953 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3953:15
+3953 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3957:3
+3957 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3957:8
+3957 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3957:10
+3957 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3957:14
+3957 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3962:0
+3962 | }
+     | ^
+error: expected `}`
+- error_stresstest:3966:11
+3966 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3966:11
+3966 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3966:15
+3966 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3970:3
+3970 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3970:8
+3970 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3970:10
+3970 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3970:14
+3970 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3975:0
+3975 | }
+     | ^
+error: expected `}`
+- error_stresstest:3979:11
+3979 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3979:11
+3979 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3979:15
+3979 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3983:3
+3983 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3983:8
+3983 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3983:10
+3983 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3983:14
+3983 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:3988:0
+3988 | }
+     | ^
+error: expected `}`
+- error_stresstest:3992:11
+3992 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:3992:11
+3992 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:3992:15
+3992 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:3996:3
+3996 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:3996:8
+3996 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:3996:10
+3996 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:3996:14
+3996 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4001:0
+4001 | }
+     | ^
+error: expected `}`
+- error_stresstest:4005:11
+4005 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4005:11
+4005 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4005:15
+4005 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4009:3
+4009 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4009:8
+4009 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4009:10
+4009 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4009:14
+4009 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4014:0
+4014 | }
+     | ^
+error: expected `}`
+- error_stresstest:4018:11
+4018 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4018:11
+4018 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4018:15
+4018 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4022:3
+4022 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4022:8
+4022 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4022:10
+4022 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4022:14
+4022 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4027:0
+4027 | }
+     | ^
+error: expected `}`
+- error_stresstest:4031:11
+4031 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4031:11
+4031 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4031:15
+4031 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4035:3
+4035 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4035:8
+4035 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4035:10
+4035 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4035:14
+4035 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4040:0
+4040 | }
+     | ^
+error: expected `}`
+- error_stresstest:4044:11
+4044 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4044:11
+4044 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4044:15
+4044 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4048:3
+4048 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4048:8
+4048 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4048:10
+4048 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4048:14
+4048 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4053:0
+4053 | }
+     | ^
+error: expected `}`
+- error_stresstest:4057:11
+4057 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4057:11
+4057 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4057:15
+4057 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4061:3
+4061 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4061:8
+4061 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4061:10
+4061 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4061:14
+4061 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4066:0
+4066 | }
+     | ^
+error: expected `}`
+- error_stresstest:4070:11
+4070 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4070:11
+4070 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4070:15
+4070 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4074:3
+4074 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4074:8
+4074 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4074:10
+4074 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4074:14
+4074 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4079:0
+4079 | }
+     | ^
+error: expected `}`
+- error_stresstest:4083:11
+4083 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4083:11
+4083 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4083:15
+4083 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4087:3
+4087 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4087:8
+4087 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4087:10
+4087 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4087:14
+4087 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4092:0
+4092 | }
+     | ^
+error: expected `}`
+- error_stresstest:4096:11
+4096 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4096:11
+4096 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4096:15
+4096 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4100:3
+4100 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4100:8
+4100 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4100:10
+4100 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4100:14
+4100 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4105:0
+4105 | }
+     | ^
+error: expected `}`
+- error_stresstest:4109:11
+4109 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4109:11
+4109 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4109:15
+4109 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4113:3
+4113 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4113:8
+4113 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4113:10
+4113 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4113:14
+4113 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4118:0
+4118 | }
+     | ^
+error: expected `}`
+- error_stresstest:4122:11
+4122 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4122:11
+4122 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4122:15
+4122 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4126:3
+4126 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4126:8
+4126 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4126:10
+4126 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4126:14
+4126 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4131:0
+4131 | }
+     | ^
+error: expected `}`
+- error_stresstest:4135:11
+4135 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4135:11
+4135 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4135:15
+4135 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4139:3
+4139 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4139:8
+4139 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4139:10
+4139 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4139:14
+4139 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4144:0
+4144 | }
+     | ^
+error: expected `}`
+- error_stresstest:4148:11
+4148 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4148:11
+4148 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4148:15
+4148 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4152:3
+4152 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4152:8
+4152 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4152:10
+4152 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4152:14
+4152 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4157:0
+4157 | }
+     | ^
+error: expected `}`
+- error_stresstest:4161:11
+4161 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4161:11
+4161 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4161:15
+4161 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4165:3
+4165 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4165:8
+4165 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4165:10
+4165 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4165:14
+4165 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4170:0
+4170 | }
+     | ^
+error: expected `}`
+- error_stresstest:4174:11
+4174 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4174:11
+4174 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4174:15
+4174 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4178:3
+4178 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4178:8
+4178 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4178:10
+4178 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4178:14
+4178 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4183:0
+4183 | }
+     | ^
+error: expected `}`
+- error_stresstest:4187:11
+4187 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4187:11
+4187 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4187:15
+4187 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4191:3
+4191 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4191:8
+4191 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4191:10
+4191 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4191:14
+4191 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4196:0
+4196 | }
+     | ^
+error: expected `}`
+- error_stresstest:4200:11
+4200 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4200:11
+4200 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4200:15
+4200 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4204:3
+4204 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4204:8
+4204 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4204:10
+4204 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4204:14
+4204 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4209:0
+4209 | }
+     | ^
+error: expected `}`
+- error_stresstest:4213:11
+4213 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4213:11
+4213 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4213:15
+4213 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4217:3
+4217 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4217:8
+4217 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4217:10
+4217 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4217:14
+4217 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4222:0
+4222 | }
+     | ^
+error: expected `}`
+- error_stresstest:4226:11
+4226 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4226:11
+4226 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4226:15
+4226 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4230:3
+4230 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4230:8
+4230 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4230:10
+4230 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4230:14
+4230 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4235:0
+4235 | }
+     | ^
+error: expected `}`
+- error_stresstest:4239:11
+4239 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4239:11
+4239 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4239:15
+4239 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4243:3
+4243 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4243:8
+4243 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4243:10
+4243 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4243:14
+4243 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4248:0
+4248 | }
+     | ^
+error: expected `}`
+- error_stresstest:4252:11
+4252 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4252:11
+4252 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4252:15
+4252 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4256:3
+4256 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4256:8
+4256 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4256:10
+4256 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4256:14
+4256 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4261:0
+4261 | }
+     | ^
+error: expected `}`
+- error_stresstest:4265:11
+4265 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4265:11
+4265 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4265:15
+4265 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4269:3
+4269 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4269:8
+4269 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4269:10
+4269 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4269:14
+4269 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4274:0
+4274 | }
+     | ^
+error: expected `}`
+- error_stresstest:4278:11
+4278 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4278:11
+4278 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4278:15
+4278 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4282:3
+4282 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4282:8
+4282 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4282:10
+4282 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4282:14
+4282 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4287:0
+4287 | }
+     | ^
+error: expected `}`
+- error_stresstest:4291:11
+4291 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4291:11
+4291 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4291:15
+4291 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4295:3
+4295 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4295:8
+4295 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4295:10
+4295 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4295:14
+4295 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4300:0
+4300 | }
+     | ^
+error: expected `}`
+- error_stresstest:4304:11
+4304 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4304:11
+4304 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4304:15
+4304 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4308:3
+4308 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4308:8
+4308 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4308:10
+4308 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4308:14
+4308 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4313:0
+4313 | }
+     | ^
+error: expected `}`
+- error_stresstest:4317:11
+4317 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4317:11
+4317 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4317:15
+4317 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4321:3
+4321 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4321:8
+4321 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4321:10
+4321 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4321:14
+4321 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4326:0
+4326 | }
+     | ^
+error: expected `}`
+- error_stresstest:4330:11
+4330 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4330:11
+4330 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4330:15
+4330 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4334:3
+4334 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4334:8
+4334 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4334:10
+4334 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4334:14
+4334 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4339:0
+4339 | }
+     | ^
+error: expected `}`
+- error_stresstest:4343:11
+4343 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4343:11
+4343 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4343:15
+4343 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4347:3
+4347 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4347:8
+4347 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4347:10
+4347 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4347:14
+4347 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4352:0
+4352 | }
+     | ^
+error: expected `}`
+- error_stresstest:4356:11
+4356 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4356:11
+4356 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4356:15
+4356 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4360:3
+4360 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4360:8
+4360 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4360:10
+4360 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4360:14
+4360 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4365:0
+4365 | }
+     | ^
+error: expected `}`
+- error_stresstest:4369:11
+4369 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4369:11
+4369 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4369:15
+4369 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4373:3
+4373 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4373:8
+4373 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4373:10
+4373 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4373:14
+4373 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4378:0
+4378 | }
+     | ^
+error: expected `}`
+- error_stresstest:4382:11
+4382 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4382:11
+4382 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4382:15
+4382 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4386:3
+4386 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4386:8
+4386 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4386:10
+4386 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4386:14
+4386 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4391:0
+4391 | }
+     | ^
+error: expected `}`
+- error_stresstest:4395:11
+4395 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4395:11
+4395 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4395:15
+4395 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4399:3
+4399 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4399:8
+4399 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4399:10
+4399 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4399:14
+4399 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4404:0
+4404 | }
+     | ^
+error: expected `}`
+- error_stresstest:4408:11
+4408 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4408:11
+4408 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4408:15
+4408 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4412:3
+4412 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4412:8
+4412 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4412:10
+4412 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4412:14
+4412 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4417:0
+4417 | }
+     | ^
+error: expected `}`
+- error_stresstest:4421:11
+4421 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4421:11
+4421 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4421:15
+4421 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4425:3
+4425 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4425:8
+4425 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4425:10
+4425 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4425:14
+4425 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4430:0
+4430 | }
+     | ^
+error: expected `}`
+- error_stresstest:4434:11
+4434 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4434:11
+4434 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4434:15
+4434 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4438:3
+4438 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4438:8
+4438 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4438:10
+4438 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4438:14
+4438 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4443:0
+4443 | }
+     | ^
+error: expected `}`
+- error_stresstest:4447:11
+4447 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4447:11
+4447 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4447:15
+4447 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4451:3
+4451 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4451:8
+4451 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4451:10
+4451 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4451:14
+4451 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4456:0
+4456 | }
+     | ^
+error: expected `}`
+- error_stresstest:4460:11
+4460 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4460:11
+4460 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4460:15
+4460 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4464:3
+4464 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4464:8
+4464 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4464:10
+4464 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4464:14
+4464 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4469:0
+4469 | }
+     | ^
+error: expected `}`
+- error_stresstest:4473:11
+4473 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4473:11
+4473 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4473:15
+4473 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4477:3
+4477 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4477:8
+4477 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4477:10
+4477 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4477:14
+4477 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4482:0
+4482 | }
+     | ^
+error: expected `}`
+- error_stresstest:4486:11
+4486 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4486:11
+4486 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4486:15
+4486 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4490:3
+4490 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4490:8
+4490 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4490:10
+4490 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4490:14
+4490 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4495:0
+4495 | }
+     | ^
+error: expected `}`
+- error_stresstest:4499:11
+4499 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4499:11
+4499 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4499:15
+4499 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4503:3
+4503 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4503:8
+4503 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4503:10
+4503 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4503:14
+4503 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4508:0
+4508 | }
+     | ^
+error: expected `}`
+- error_stresstest:4512:11
+4512 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4512:11
+4512 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4512:15
+4512 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4516:3
+4516 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4516:8
+4516 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4516:10
+4516 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4516:14
+4516 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4521:0
+4521 | }
+     | ^
+error: expected `}`
+- error_stresstest:4525:11
+4525 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4525:11
+4525 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4525:15
+4525 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4529:3
+4529 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4529:8
+4529 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4529:10
+4529 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4529:14
+4529 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4534:0
+4534 | }
+     | ^
+error: expected `}`
+- error_stresstest:4538:11
+4538 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4538:11
+4538 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4538:15
+4538 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4542:3
+4542 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4542:8
+4542 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4542:10
+4542 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4542:14
+4542 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4547:0
+4547 | }
+     | ^
+error: expected `}`
+- error_stresstest:4551:11
+4551 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4551:11
+4551 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4551:15
+4551 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4555:3
+4555 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4555:8
+4555 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4555:10
+4555 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4555:14
+4555 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4560:0
+4560 | }
+     | ^
+error: expected `}`
+- error_stresstest:4564:11
+4564 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4564:11
+4564 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4564:15
+4564 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4568:3
+4568 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4568:8
+4568 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4568:10
+4568 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4568:14
+4568 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4573:0
+4573 | }
+     | ^
+error: expected `}`
+- error_stresstest:4577:11
+4577 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4577:11
+4577 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4577:15
+4577 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4581:3
+4581 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4581:8
+4581 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4581:10
+4581 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4581:14
+4581 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4586:0
+4586 | }
+     | ^
+error: expected `}`
+- error_stresstest:4590:11
+4590 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4590:11
+4590 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4590:15
+4590 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4594:3
+4594 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4594:8
+4594 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4594:10
+4594 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4594:14
+4594 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4599:0
+4599 | }
+     | ^
+error: expected `}`
+- error_stresstest:4603:11
+4603 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4603:11
+4603 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4603:15
+4603 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4607:3
+4607 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4607:8
+4607 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4607:10
+4607 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4607:14
+4607 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4612:0
+4612 | }
+     | ^
+error: expected `}`
+- error_stresstest:4616:11
+4616 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4616:11
+4616 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4616:15
+4616 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4620:3
+4620 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4620:8
+4620 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4620:10
+4620 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4620:14
+4620 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4625:0
+4625 | }
+     | ^
+error: expected `}`
+- error_stresstest:4629:11
+4629 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4629:11
+4629 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4629:15
+4629 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4633:3
+4633 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4633:8
+4633 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4633:10
+4633 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4633:14
+4633 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4638:0
+4638 | }
+     | ^
+error: expected `}`
+- error_stresstest:4642:11
+4642 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4642:11
+4642 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4642:15
+4642 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4646:3
+4646 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4646:8
+4646 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4646:10
+4646 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4646:14
+4646 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4651:0
+4651 | }
+     | ^
+error: expected `}`
+- error_stresstest:4655:11
+4655 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4655:11
+4655 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4655:15
+4655 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4659:3
+4659 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4659:8
+4659 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4659:10
+4659 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4659:14
+4659 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4664:0
+4664 | }
+     | ^
+error: expected `}`
+- error_stresstest:4668:11
+4668 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4668:11
+4668 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4668:15
+4668 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4672:3
+4672 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4672:8
+4672 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4672:10
+4672 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4672:14
+4672 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4677:0
+4677 | }
+     | ^
+error: expected `}`
+- error_stresstest:4681:11
+4681 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4681:11
+4681 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4681:15
+4681 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4685:3
+4685 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4685:8
+4685 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4685:10
+4685 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4685:14
+4685 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4690:0
+4690 | }
+     | ^
+error: expected `}`
+- error_stresstest:4694:11
+4694 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4694:11
+4694 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4694:15
+4694 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4698:3
+4698 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4698:8
+4698 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4698:10
+4698 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4698:14
+4698 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4703:0
+4703 | }
+     | ^
+error: expected `}`
+- error_stresstest:4707:11
+4707 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4707:11
+4707 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4707:15
+4707 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4711:3
+4711 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4711:8
+4711 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4711:10
+4711 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4711:14
+4711 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4716:0
+4716 | }
+     | ^
+error: expected `}`
+- error_stresstest:4720:11
+4720 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4720:11
+4720 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4720:15
+4720 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4724:3
+4724 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4724:8
+4724 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4724:10
+4724 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4724:14
+4724 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4729:0
+4729 | }
+     | ^
+error: expected `}`
+- error_stresstest:4733:11
+4733 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4733:11
+4733 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4733:15
+4733 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4737:3
+4737 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4737:8
+4737 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4737:10
+4737 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4737:14
+4737 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4742:0
+4742 | }
+     | ^
+error: expected `}`
+- error_stresstest:4746:11
+4746 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4746:11
+4746 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4746:15
+4746 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4750:3
+4750 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4750:8
+4750 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4750:10
+4750 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4750:14
+4750 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4755:0
+4755 | }
+     | ^
+error: expected `}`
+- error_stresstest:4759:11
+4759 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4759:11
+4759 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4759:15
+4759 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4763:3
+4763 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4763:8
+4763 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4763:10
+4763 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4763:14
+4763 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4768:0
+4768 | }
+     | ^
+error: expected `}`
+- error_stresstest:4772:11
+4772 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4772:11
+4772 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4772:15
+4772 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4776:3
+4776 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4776:8
+4776 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4776:10
+4776 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4776:14
+4776 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4781:0
+4781 | }
+     | ^
+error: expected `}`
+- error_stresstest:4785:11
+4785 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4785:11
+4785 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4785:15
+4785 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4789:3
+4789 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4789:8
+4789 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4789:10
+4789 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4789:14
+4789 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4794:0
+4794 | }
+     | ^
+error: expected `}`
+- error_stresstest:4798:11
+4798 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4798:11
+4798 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4798:15
+4798 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4802:3
+4802 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4802:8
+4802 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4802:10
+4802 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4802:14
+4802 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4807:0
+4807 | }
+     | ^
+error: expected `}`
+- error_stresstest:4811:11
+4811 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4811:11
+4811 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4811:15
+4811 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4815:3
+4815 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4815:8
+4815 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4815:10
+4815 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4815:14
+4815 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4820:0
+4820 | }
+     | ^
+error: expected `}`
+- error_stresstest:4824:11
+4824 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4824:11
+4824 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4824:15
+4824 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4828:3
+4828 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4828:8
+4828 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4828:10
+4828 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4828:14
+4828 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4833:0
+4833 | }
+     | ^
+error: expected `}`
+- error_stresstest:4837:11
+4837 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4837:11
+4837 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4837:15
+4837 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4841:3
+4841 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4841:8
+4841 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4841:10
+4841 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4841:14
+4841 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4846:0
+4846 | }
+     | ^
+error: expected `}`
+- error_stresstest:4850:11
+4850 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4850:11
+4850 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4850:15
+4850 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4854:3
+4854 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4854:8
+4854 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4854:10
+4854 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4854:14
+4854 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4859:0
+4859 | }
+     | ^
+error: expected `}`
+- error_stresstest:4863:11
+4863 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4863:11
+4863 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4863:15
+4863 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4867:3
+4867 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4867:8
+4867 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4867:10
+4867 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4867:14
+4867 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4872:0
+4872 | }
+     | ^
+error: expected `}`
+- error_stresstest:4876:11
+4876 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4876:11
+4876 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4876:15
+4876 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4880:3
+4880 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4880:8
+4880 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4880:10
+4880 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4880:14
+4880 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4885:0
+4885 | }
+     | ^
+error: expected `}`
+- error_stresstest:4889:11
+4889 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4889:11
+4889 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4889:15
+4889 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4893:3
+4893 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4893:8
+4893 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4893:10
+4893 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4893:14
+4893 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4898:0
+4898 | }
+     | ^
+error: expected `}`
+- error_stresstest:4902:11
+4902 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4902:11
+4902 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4902:15
+4902 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4906:3
+4906 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4906:8
+4906 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4906:10
+4906 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4906:14
+4906 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4911:0
+4911 | }
+     | ^
+error: expected `}`
+- error_stresstest:4915:11
+4915 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4915:11
+4915 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4915:15
+4915 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4919:3
+4919 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4919:8
+4919 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4919:10
+4919 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4919:14
+4919 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4924:0
+4924 | }
+     | ^
+error: expected `}`
+- error_stresstest:4928:11
+4928 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4928:11
+4928 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4928:15
+4928 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4932:3
+4932 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4932:8
+4932 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4932:10
+4932 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4932:14
+4932 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4937:0
+4937 | }
+     | ^
+error: expected `}`
+- error_stresstest:4941:11
+4941 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4941:11
+4941 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4941:15
+4941 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4945:3
+4945 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4945:8
+4945 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4945:10
+4945 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4945:14
+4945 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4950:0
+4950 | }
+     | ^
+error: expected `}`
+- error_stresstest:4954:11
+4954 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4954:11
+4954 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4954:15
+4954 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4958:3
+4958 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4958:8
+4958 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4958:10
+4958 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4958:14
+4958 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4963:0
+4963 | }
+     | ^
+error: expected `}`
+- error_stresstest:4967:11
+4967 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4967:11
+4967 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4967:15
+4967 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4971:3
+4971 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4971:8
+4971 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4971:10
+4971 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4971:14
+4971 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4976:0
+4976 | }
+     | ^
+error: expected `}`
+- error_stresstest:4980:11
+4980 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4980:11
+4980 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4980:15
+4980 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4984:3
+4984 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4984:8
+4984 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4984:10
+4984 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4984:14
+4984 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:4989:0
+4989 | }
+     | ^
+error: expected `}`
+- error_stresstest:4993:11
+4993 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:4993:11
+4993 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:4993:15
+4993 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:4997:3
+4997 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:4997:8
+4997 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:4997:10
+4997 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:4997:14
+4997 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5002:0
+5002 | }
+     | ^
+error: expected `}`
+- error_stresstest:5006:11
+5006 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5006:11
+5006 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5006:15
+5006 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5010:3
+5010 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5010:8
+5010 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5010:10
+5010 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5010:14
+5010 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5015:0
+5015 | }
+     | ^
+error: expected `}`
+- error_stresstest:5019:11
+5019 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5019:11
+5019 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5019:15
+5019 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5023:3
+5023 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5023:8
+5023 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5023:10
+5023 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5023:14
+5023 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5028:0
+5028 | }
+     | ^
+error: expected `}`
+- error_stresstest:5032:11
+5032 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5032:11
+5032 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5032:15
+5032 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5036:3
+5036 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5036:8
+5036 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5036:10
+5036 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5036:14
+5036 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5041:0
+5041 | }
+     | ^
+error: expected `}`
+- error_stresstest:5045:11
+5045 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5045:11
+5045 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5045:15
+5045 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5049:3
+5049 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5049:8
+5049 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5049:10
+5049 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5049:14
+5049 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5054:0
+5054 | }
+     | ^
+error: expected `}`
+- error_stresstest:5058:11
+5058 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5058:11
+5058 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5058:15
+5058 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5062:3
+5062 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5062:8
+5062 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5062:10
+5062 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5062:14
+5062 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5067:0
+5067 | }
+     | ^
+error: expected `}`
+- error_stresstest:5071:11
+5071 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5071:11
+5071 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5071:15
+5071 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5075:3
+5075 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5075:8
+5075 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5075:10
+5075 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5075:14
+5075 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5080:0
+5080 | }
+     | ^
+error: expected `}`
+- error_stresstest:5084:11
+5084 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5084:11
+5084 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5084:15
+5084 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5088:3
+5088 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5088:8
+5088 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5088:10
+5088 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5088:14
+5088 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5093:0
+5093 | }
+     | ^
+error: expected `}`
+- error_stresstest:5097:11
+5097 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5097:11
+5097 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5097:15
+5097 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5101:3
+5101 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5101:8
+5101 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5101:10
+5101 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5101:14
+5101 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5106:0
+5106 | }
+     | ^
+error: expected `}`
+- error_stresstest:5110:11
+5110 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5110:11
+5110 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5110:15
+5110 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5114:3
+5114 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5114:8
+5114 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5114:10
+5114 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5114:14
+5114 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5119:0
+5119 | }
+     | ^
+error: expected `}`
+- error_stresstest:5123:11
+5123 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5123:11
+5123 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5123:15
+5123 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5127:3
+5127 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5127:8
+5127 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5127:10
+5127 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5127:14
+5127 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5132:0
+5132 | }
+     | ^
+error: expected `}`
+- error_stresstest:5136:11
+5136 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5136:11
+5136 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5136:15
+5136 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5140:3
+5140 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5140:8
+5140 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5140:10
+5140 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5140:14
+5140 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5145:0
+5145 | }
+     | ^
+error: expected `}`
+- error_stresstest:5149:11
+5149 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5149:11
+5149 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5149:15
+5149 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5153:3
+5153 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5153:8
+5153 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5153:10
+5153 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5153:14
+5153 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5158:0
+5158 | }
+     | ^
+error: expected `}`
+- error_stresstest:5162:11
+5162 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5162:11
+5162 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5162:15
+5162 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5166:3
+5166 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5166:8
+5166 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5166:10
+5166 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5166:14
+5166 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5171:0
+5171 | }
+     | ^
+error: expected `}`
+- error_stresstest:5175:11
+5175 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5175:11
+5175 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5175:15
+5175 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5179:3
+5179 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5179:8
+5179 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5179:10
+5179 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5179:14
+5179 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5184:0
+5184 | }
+     | ^
+error: expected `}`
+- error_stresstest:5188:11
+5188 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5188:11
+5188 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5188:15
+5188 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5192:3
+5192 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5192:8
+5192 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5192:10
+5192 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5192:14
+5192 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5197:0
+5197 | }
+     | ^
+error: expected `}`
+- error_stresstest:5201:11
+5201 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5201:11
+5201 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5201:15
+5201 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5205:3
+5205 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5205:8
+5205 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5205:10
+5205 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5205:14
+5205 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5210:0
+5210 | }
+     | ^
+error: expected `}`
+- error_stresstest:5214:11
+5214 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5214:11
+5214 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5214:15
+5214 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5218:3
+5218 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5218:8
+5218 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5218:10
+5218 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5218:14
+5218 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5223:0
+5223 | }
+     | ^
+error: expected `}`
+- error_stresstest:5227:11
+5227 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5227:11
+5227 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5227:15
+5227 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5231:3
+5231 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5231:8
+5231 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5231:10
+5231 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5231:14
+5231 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5236:0
+5236 | }
+     | ^
+error: expected `}`
+- error_stresstest:5240:11
+5240 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5240:11
+5240 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5240:15
+5240 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5244:3
+5244 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5244:8
+5244 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5244:10
+5244 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5244:14
+5244 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5249:0
+5249 | }
+     | ^
+error: expected `}`
+- error_stresstest:5253:11
+5253 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5253:11
+5253 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5253:15
+5253 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5257:3
+5257 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5257:8
+5257 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5257:10
+5257 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5257:14
+5257 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5262:0
+5262 | }
+     | ^
+error: expected `}`
+- error_stresstest:5266:11
+5266 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5266:11
+5266 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5266:15
+5266 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5270:3
+5270 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5270:8
+5270 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5270:10
+5270 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5270:14
+5270 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5275:0
+5275 | }
+     | ^
+error: expected `}`
+- error_stresstest:5279:11
+5279 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5279:11
+5279 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5279:15
+5279 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5283:3
+5283 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5283:8
+5283 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5283:10
+5283 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5283:14
+5283 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5288:0
+5288 | }
+     | ^
+error: expected `}`
+- error_stresstest:5292:11
+5292 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5292:11
+5292 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5292:15
+5292 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5296:3
+5296 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5296:8
+5296 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5296:10
+5296 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5296:14
+5296 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5301:0
+5301 | }
+     | ^
+error: expected `}`
+- error_stresstest:5305:11
+5305 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5305:11
+5305 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5305:15
+5305 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5309:3
+5309 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5309:8
+5309 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5309:10
+5309 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5309:14
+5309 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5314:0
+5314 | }
+     | ^
+error: expected `}`
+- error_stresstest:5318:11
+5318 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5318:11
+5318 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5318:15
+5318 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5322:3
+5322 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5322:8
+5322 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5322:10
+5322 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5322:14
+5322 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5327:0
+5327 | }
+     | ^
+error: expected `}`
+- error_stresstest:5331:11
+5331 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5331:11
+5331 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5331:15
+5331 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5335:3
+5335 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5335:8
+5335 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5335:10
+5335 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5335:14
+5335 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5340:0
+5340 | }
+     | ^
+error: expected `}`
+- error_stresstest:5344:11
+5344 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5344:11
+5344 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5344:15
+5344 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5348:3
+5348 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5348:8
+5348 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5348:10
+5348 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5348:14
+5348 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5353:0
+5353 | }
+     | ^
+error: expected `}`
+- error_stresstest:5357:11
+5357 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5357:11
+5357 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5357:15
+5357 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5361:3
+5361 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5361:8
+5361 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5361:10
+5361 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5361:14
+5361 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5366:0
+5366 | }
+     | ^
+error: expected `}`
+- error_stresstest:5370:11
+5370 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5370:11
+5370 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5370:15
+5370 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5374:3
+5374 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5374:8
+5374 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5374:10
+5374 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5374:14
+5374 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5379:0
+5379 | }
+     | ^
+error: expected `}`
+- error_stresstest:5383:11
+5383 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5383:11
+5383 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5383:15
+5383 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5387:3
+5387 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5387:8
+5387 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5387:10
+5387 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5387:14
+5387 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5392:0
+5392 | }
+     | ^
+error: expected `}`
+- error_stresstest:5396:11
+5396 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5396:11
+5396 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5396:15
+5396 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5400:3
+5400 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5400:8
+5400 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5400:10
+5400 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5400:14
+5400 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5405:0
+5405 | }
+     | ^
+error: expected `}`
+- error_stresstest:5409:11
+5409 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5409:11
+5409 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5409:15
+5409 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5413:3
+5413 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5413:8
+5413 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5413:10
+5413 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5413:14
+5413 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5418:0
+5418 | }
+     | ^
+error: expected `}`
+- error_stresstest:5422:11
+5422 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5422:11
+5422 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5422:15
+5422 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5426:3
+5426 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5426:8
+5426 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5426:10
+5426 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5426:14
+5426 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5431:0
+5431 | }
+     | ^
+error: expected `}`
+- error_stresstest:5435:11
+5435 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5435:11
+5435 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5435:15
+5435 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5439:3
+5439 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5439:8
+5439 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5439:10
+5439 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5439:14
+5439 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5444:0
+5444 | }
+     | ^
+error: expected `}`
+- error_stresstest:5448:11
+5448 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5448:11
+5448 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5448:15
+5448 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5452:3
+5452 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5452:8
+5452 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5452:10
+5452 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5452:14
+5452 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5457:0
+5457 | }
+     | ^
+error: expected `}`
+- error_stresstest:5461:11
+5461 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5461:11
+5461 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5461:15
+5461 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5465:3
+5465 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5465:8
+5465 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5465:10
+5465 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5465:14
+5465 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5470:0
+5470 | }
+     | ^
+error: expected `}`
+- error_stresstest:5474:11
+5474 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5474:11
+5474 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5474:15
+5474 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5478:3
+5478 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5478:8
+5478 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5478:10
+5478 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5478:14
+5478 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5483:0
+5483 | }
+     | ^
+error: expected `}`
+- error_stresstest:5487:11
+5487 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5487:11
+5487 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5487:15
+5487 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5491:3
+5491 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5491:8
+5491 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5491:10
+5491 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5491:14
+5491 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5496:0
+5496 | }
+     | ^
+error: expected `}`
+- error_stresstest:5500:11
+5500 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5500:11
+5500 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5500:15
+5500 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5504:3
+5504 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5504:8
+5504 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5504:10
+5504 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5504:14
+5504 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5509:0
+5509 | }
+     | ^
+error: expected `}`
+- error_stresstest:5513:11
+5513 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5513:11
+5513 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5513:15
+5513 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5517:3
+5517 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5517:8
+5517 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5517:10
+5517 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5517:14
+5517 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5522:0
+5522 | }
+     | ^
+error: expected `}`
+- error_stresstest:5526:11
+5526 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5526:11
+5526 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5526:15
+5526 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5530:3
+5530 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5530:8
+5530 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5530:10
+5530 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5530:14
+5530 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5535:0
+5535 | }
+     | ^
+error: expected `}`
+- error_stresstest:5539:11
+5539 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5539:11
+5539 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5539:15
+5539 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5543:3
+5543 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5543:8
+5543 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5543:10
+5543 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5543:14
+5543 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5548:0
+5548 | }
+     | ^
+error: expected `}`
+- error_stresstest:5552:11
+5552 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5552:11
+5552 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5552:15
+5552 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5556:3
+5556 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5556:8
+5556 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5556:10
+5556 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5556:14
+5556 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5561:0
+5561 | }
+     | ^
+error: expected `}`
+- error_stresstest:5565:11
+5565 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5565:11
+5565 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5565:15
+5565 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5569:3
+5569 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5569:8
+5569 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5569:10
+5569 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5569:14
+5569 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5574:0
+5574 | }
+     | ^
+error: expected `}`
+- error_stresstest:5578:11
+5578 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5578:11
+5578 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5578:15
+5578 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5582:3
+5582 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5582:8
+5582 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5582:10
+5582 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5582:14
+5582 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5587:0
+5587 | }
+     | ^
+error: expected `}`
+- error_stresstest:5591:11
+5591 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5591:11
+5591 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5591:15
+5591 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5595:3
+5595 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5595:8
+5595 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5595:10
+5595 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5595:14
+5595 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5600:0
+5600 | }
+     | ^
+error: expected `}`
+- error_stresstest:5604:11
+5604 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5604:11
+5604 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5604:15
+5604 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5608:3
+5608 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5608:8
+5608 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5608:10
+5608 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5608:14
+5608 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5613:0
+5613 | }
+     | ^
+error: expected `}`
+- error_stresstest:5617:11
+5617 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5617:11
+5617 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5617:15
+5617 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5621:3
+5621 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5621:8
+5621 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5621:10
+5621 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5621:14
+5621 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5626:0
+5626 | }
+     | ^
+error: expected `}`
+- error_stresstest:5630:11
+5630 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5630:11
+5630 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5630:15
+5630 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5634:3
+5634 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5634:8
+5634 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5634:10
+5634 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5634:14
+5634 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5639:0
+5639 | }
+     | ^
+error: expected `}`
+- error_stresstest:5643:11
+5643 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5643:11
+5643 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5643:15
+5643 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5647:3
+5647 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5647:8
+5647 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5647:10
+5647 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5647:14
+5647 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5652:0
+5652 | }
+     | ^
+error: expected `}`
+- error_stresstest:5656:11
+5656 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5656:11
+5656 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5656:15
+5656 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5660:3
+5660 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5660:8
+5660 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5660:10
+5660 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5660:14
+5660 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5665:0
+5665 | }
+     | ^
+error: expected `}`
+- error_stresstest:5669:11
+5669 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5669:11
+5669 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5669:15
+5669 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5673:3
+5673 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5673:8
+5673 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5673:10
+5673 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5673:14
+5673 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5678:0
+5678 | }
+     | ^
+error: expected `}`
+- error_stresstest:5682:11
+5682 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5682:11
+5682 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5682:15
+5682 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5686:3
+5686 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5686:8
+5686 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5686:10
+5686 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5686:14
+5686 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5691:0
+5691 | }
+     | ^
+error: expected `}`
+- error_stresstest:5695:11
+5695 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5695:11
+5695 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5695:15
+5695 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5699:3
+5699 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5699:8
+5699 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5699:10
+5699 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5699:14
+5699 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5704:0
+5704 | }
+     | ^
+error: expected `}`
+- error_stresstest:5708:11
+5708 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5708:11
+5708 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5708:15
+5708 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5712:3
+5712 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5712:8
+5712 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5712:10
+5712 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5712:14
+5712 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5717:0
+5717 | }
+     | ^
+error: expected `}`
+- error_stresstest:5721:11
+5721 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5721:11
+5721 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5721:15
+5721 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5725:3
+5725 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5725:8
+5725 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5725:10
+5725 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5725:14
+5725 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5730:0
+5730 | }
+     | ^
+error: expected `}`
+- error_stresstest:5734:11
+5734 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5734:11
+5734 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5734:15
+5734 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5738:3
+5738 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5738:8
+5738 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5738:10
+5738 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5738:14
+5738 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5743:0
+5743 | }
+     | ^
+error: expected `}`
+- error_stresstest:5747:11
+5747 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5747:11
+5747 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5747:15
+5747 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5751:3
+5751 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5751:8
+5751 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5751:10
+5751 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5751:14
+5751 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5756:0
+5756 | }
+     | ^
+error: expected `}`
+- error_stresstest:5760:11
+5760 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5760:11
+5760 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5760:15
+5760 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5764:3
+5764 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5764:8
+5764 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5764:10
+5764 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5764:14
+5764 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5769:0
+5769 | }
+     | ^
+error: expected `}`
+- error_stresstest:5773:11
+5773 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5773:11
+5773 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5773:15
+5773 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5777:3
+5777 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5777:8
+5777 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5777:10
+5777 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5777:14
+5777 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5782:0
+5782 | }
+     | ^
+error: expected `}`
+- error_stresstest:5786:11
+5786 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5786:11
+5786 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5786:15
+5786 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5790:3
+5790 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5790:8
+5790 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5790:10
+5790 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5790:14
+5790 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5795:0
+5795 | }
+     | ^
+error: expected `}`
+- error_stresstest:5799:11
+5799 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5799:11
+5799 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5799:15
+5799 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5803:3
+5803 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5803:8
+5803 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5803:10
+5803 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5803:14
+5803 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5808:0
+5808 | }
+     | ^
+error: expected `}`
+- error_stresstest:5812:11
+5812 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5812:11
+5812 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5812:15
+5812 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5816:3
+5816 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5816:8
+5816 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5816:10
+5816 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5816:14
+5816 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5821:0
+5821 | }
+     | ^
+error: expected `}`
+- error_stresstest:5825:11
+5825 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5825:11
+5825 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5825:15
+5825 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5829:3
+5829 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5829:8
+5829 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5829:10
+5829 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5829:14
+5829 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5834:0
+5834 | }
+     | ^
+error: expected `}`
+- error_stresstest:5838:11
+5838 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5838:11
+5838 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5838:15
+5838 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5842:3
+5842 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5842:8
+5842 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5842:10
+5842 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5842:14
+5842 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5847:0
+5847 | }
+     | ^
+error: expected `}`
+- error_stresstest:5851:11
+5851 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5851:11
+5851 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5851:15
+5851 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5855:3
+5855 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5855:8
+5855 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5855:10
+5855 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5855:14
+5855 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5860:0
+5860 | }
+     | ^
+error: expected `}`
+- error_stresstest:5864:11
+5864 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5864:11
+5864 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5864:15
+5864 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5868:3
+5868 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5868:8
+5868 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5868:10
+5868 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5868:14
+5868 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5873:0
+5873 | }
+     | ^
+error: expected `}`
+- error_stresstest:5877:11
+5877 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5877:11
+5877 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5877:15
+5877 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5881:3
+5881 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5881:8
+5881 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5881:10
+5881 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5881:14
+5881 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5886:0
+5886 | }
+     | ^
+error: expected `}`
+- error_stresstest:5890:11
+5890 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5890:11
+5890 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5890:15
+5890 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5894:3
+5894 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5894:8
+5894 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5894:10
+5894 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5894:14
+5894 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5899:0
+5899 | }
+     | ^
+error: expected `}`
+- error_stresstest:5903:11
+5903 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5903:11
+5903 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5903:15
+5903 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5907:3
+5907 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5907:8
+5907 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5907:10
+5907 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5907:14
+5907 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5912:0
+5912 | }
+     | ^
+error: expected `}`
+- error_stresstest:5916:11
+5916 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5916:11
+5916 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5916:15
+5916 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5920:3
+5920 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5920:8
+5920 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5920:10
+5920 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5920:14
+5920 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5925:0
+5925 | }
+     | ^
+error: expected `}`
+- error_stresstest:5929:11
+5929 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5929:11
+5929 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5929:15
+5929 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5933:3
+5933 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5933:8
+5933 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5933:10
+5933 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5933:14
+5933 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5938:0
+5938 | }
+     | ^
+error: expected `}`
+- error_stresstest:5942:11
+5942 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5942:11
+5942 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5942:15
+5942 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5946:3
+5946 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5946:8
+5946 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5946:10
+5946 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5946:14
+5946 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5951:0
+5951 | }
+     | ^
+error: expected `}`
+- error_stresstest:5955:11
+5955 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5955:11
+5955 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5955:15
+5955 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5959:3
+5959 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5959:8
+5959 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5959:10
+5959 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5959:14
+5959 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5964:0
+5964 | }
+     | ^
+error: expected `}`
+- error_stresstest:5968:11
+5968 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5968:11
+5968 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5968:15
+5968 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5972:3
+5972 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5972:8
+5972 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5972:10
+5972 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5972:14
+5972 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5977:0
+5977 | }
+     | ^
+error: expected `}`
+- error_stresstest:5981:11
+5981 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5981:11
+5981 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5981:15
+5981 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5985:3
+5985 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5985:8
+5985 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5985:10
+5985 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5985:14
+5985 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:5990:0
+5990 | }
+     | ^
+error: expected `}`
+- error_stresstest:5994:11
+5994 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:5994:11
+5994 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:5994:15
+5994 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:5998:3
+5998 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:5998:8
+5998 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:5998:10
+5998 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:5998:14
+5998 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6003:0
+6003 | }
+     | ^
+error: expected `}`
+- error_stresstest:6007:11
+6007 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6007:11
+6007 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6007:15
+6007 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6011:3
+6011 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6011:8
+6011 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6011:10
+6011 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6011:14
+6011 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6016:0
+6016 | }
+     | ^
+error: expected `}`
+- error_stresstest:6020:11
+6020 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6020:11
+6020 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6020:15
+6020 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6024:3
+6024 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6024:8
+6024 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6024:10
+6024 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6024:14
+6024 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6029:0
+6029 | }
+     | ^
+error: expected `}`
+- error_stresstest:6033:11
+6033 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6033:11
+6033 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6033:15
+6033 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6037:3
+6037 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6037:8
+6037 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6037:10
+6037 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6037:14
+6037 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6042:0
+6042 | }
+     | ^
+error: expected `}`
+- error_stresstest:6046:11
+6046 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6046:11
+6046 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6046:15
+6046 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6050:3
+6050 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6050:8
+6050 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6050:10
+6050 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6050:14
+6050 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6055:0
+6055 | }
+     | ^
+error: expected `}`
+- error_stresstest:6059:11
+6059 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6059:11
+6059 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6059:15
+6059 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6063:3
+6063 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6063:8
+6063 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6063:10
+6063 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6063:14
+6063 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6068:0
+6068 | }
+     | ^
+error: expected `}`
+- error_stresstest:6072:11
+6072 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6072:11
+6072 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6072:15
+6072 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6076:3
+6076 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6076:8
+6076 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6076:10
+6076 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6076:14
+6076 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6081:0
+6081 | }
+     | ^
+error: expected `}`
+- error_stresstest:6085:11
+6085 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6085:11
+6085 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6085:15
+6085 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6089:3
+6089 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6089:8
+6089 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6089:10
+6089 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6089:14
+6089 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6094:0
+6094 | }
+     | ^
+error: expected `}`
+- error_stresstest:6098:11
+6098 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6098:11
+6098 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6098:15
+6098 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6102:3
+6102 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6102:8
+6102 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6102:10
+6102 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6102:14
+6102 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6107:0
+6107 | }
+     | ^
+error: expected `}`
+- error_stresstest:6111:11
+6111 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6111:11
+6111 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6111:15
+6111 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6115:3
+6115 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6115:8
+6115 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6115:10
+6115 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6115:14
+6115 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6120:0
+6120 | }
+     | ^
+error: expected `}`
+- error_stresstest:6124:11
+6124 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6124:11
+6124 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6124:15
+6124 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6128:3
+6128 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6128:8
+6128 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6128:10
+6128 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6128:14
+6128 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6133:0
+6133 | }
+     | ^
+error: expected `}`
+- error_stresstest:6137:11
+6137 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6137:11
+6137 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6137:15
+6137 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6141:3
+6141 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6141:8
+6141 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6141:10
+6141 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6141:14
+6141 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6146:0
+6146 | }
+     | ^
+error: expected `}`
+- error_stresstest:6150:11
+6150 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6150:11
+6150 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6150:15
+6150 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6154:3
+6154 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6154:8
+6154 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6154:10
+6154 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6154:14
+6154 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6159:0
+6159 | }
+     | ^
+error: expected `}`
+- error_stresstest:6163:11
+6163 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6163:11
+6163 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6163:15
+6163 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6167:3
+6167 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6167:8
+6167 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6167:10
+6167 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6167:14
+6167 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6172:0
+6172 | }
+     | ^
+error: expected `}`
+- error_stresstest:6176:11
+6176 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6176:11
+6176 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6176:15
+6176 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6180:3
+6180 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6180:8
+6180 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6180:10
+6180 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6180:14
+6180 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6185:0
+6185 | }
+     | ^
+error: expected `}`
+- error_stresstest:6189:11
+6189 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6189:11
+6189 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6189:15
+6189 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6193:3
+6193 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6193:8
+6193 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6193:10
+6193 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6193:14
+6193 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6198:0
+6198 | }
+     | ^
+error: expected `}`
+- error_stresstest:6202:11
+6202 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6202:11
+6202 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6202:15
+6202 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6206:3
+6206 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6206:8
+6206 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6206:10
+6206 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6206:14
+6206 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6211:0
+6211 | }
+     | ^
+error: expected `}`
+- error_stresstest:6215:11
+6215 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6215:11
+6215 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6215:15
+6215 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6219:3
+6219 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6219:8
+6219 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6219:10
+6219 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6219:14
+6219 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6224:0
+6224 | }
+     | ^
+error: expected `}`
+- error_stresstest:6228:11
+6228 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6228:11
+6228 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6228:15
+6228 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6232:3
+6232 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6232:8
+6232 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6232:10
+6232 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6232:14
+6232 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6237:0
+6237 | }
+     | ^
+error: expected `}`
+- error_stresstest:6241:11
+6241 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6241:11
+6241 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6241:15
+6241 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6245:3
+6245 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6245:8
+6245 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6245:10
+6245 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6245:14
+6245 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6250:0
+6250 | }
+     | ^
+error: expected `}`
+- error_stresstest:6254:11
+6254 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6254:11
+6254 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6254:15
+6254 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6258:3
+6258 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6258:8
+6258 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6258:10
+6258 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6258:14
+6258 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6263:0
+6263 | }
+     | ^
+error: expected `}`
+- error_stresstest:6267:11
+6267 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6267:11
+6267 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6267:15
+6267 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6271:3
+6271 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6271:8
+6271 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6271:10
+6271 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6271:14
+6271 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6276:0
+6276 | }
+     | ^
+error: expected `}`
+- error_stresstest:6280:11
+6280 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6280:11
+6280 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6280:15
+6280 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6284:3
+6284 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6284:8
+6284 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6284:10
+6284 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6284:14
+6284 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6289:0
+6289 | }
+     | ^
+error: expected `}`
+- error_stresstest:6293:11
+6293 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6293:11
+6293 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6293:15
+6293 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6297:3
+6297 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6297:8
+6297 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6297:10
+6297 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6297:14
+6297 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6302:0
+6302 | }
+     | ^
+error: expected `}`
+- error_stresstest:6306:11
+6306 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6306:11
+6306 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6306:15
+6306 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6310:3
+6310 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6310:8
+6310 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6310:10
+6310 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6310:14
+6310 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6315:0
+6315 | }
+     | ^
+error: expected `}`
+- error_stresstest:6319:11
+6319 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6319:11
+6319 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6319:15
+6319 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6323:3
+6323 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6323:8
+6323 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6323:10
+6323 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6323:14
+6323 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6328:0
+6328 | }
+     | ^
+error: expected `}`
+- error_stresstest:6332:11
+6332 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6332:11
+6332 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6332:15
+6332 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6336:3
+6336 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6336:8
+6336 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6336:10
+6336 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6336:14
+6336 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6341:0
+6341 | }
+     | ^
+error: expected `}`
+- error_stresstest:6345:11
+6345 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6345:11
+6345 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6345:15
+6345 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6349:3
+6349 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6349:8
+6349 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6349:10
+6349 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6349:14
+6349 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6354:0
+6354 | }
+     | ^
+error: expected `}`
+- error_stresstest:6358:11
+6358 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6358:11
+6358 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6358:15
+6358 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6362:3
+6362 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6362:8
+6362 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6362:10
+6362 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6362:14
+6362 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6367:0
+6367 | }
+     | ^
+error: expected `}`
+- error_stresstest:6371:11
+6371 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6371:11
+6371 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6371:15
+6371 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6375:3
+6375 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6375:8
+6375 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6375:10
+6375 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6375:14
+6375 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6380:0
+6380 | }
+     | ^
+error: expected `}`
+- error_stresstest:6384:11
+6384 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6384:11
+6384 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6384:15
+6384 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6388:3
+6388 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6388:8
+6388 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6388:10
+6388 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6388:14
+6388 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6393:0
+6393 | }
+     | ^
+error: expected `}`
+- error_stresstest:6397:11
+6397 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6397:11
+6397 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6397:15
+6397 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6401:3
+6401 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6401:8
+6401 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6401:10
+6401 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6401:14
+6401 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6406:0
+6406 | }
+     | ^
+error: expected `}`
+- error_stresstest:6410:11
+6410 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6410:11
+6410 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6410:15
+6410 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6414:3
+6414 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6414:8
+6414 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6414:10
+6414 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6414:14
+6414 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6419:0
+6419 | }
+     | ^
+error: expected `}`
+- error_stresstest:6423:11
+6423 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6423:11
+6423 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6423:15
+6423 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6427:3
+6427 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6427:8
+6427 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6427:10
+6427 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6427:14
+6427 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6432:0
+6432 | }
+     | ^
+error: expected `}`
+- error_stresstest:6436:11
+6436 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6436:11
+6436 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6436:15
+6436 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6440:3
+6440 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6440:8
+6440 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6440:10
+6440 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6440:14
+6440 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6445:0
+6445 | }
+     | ^
+error: expected `}`
+- error_stresstest:6449:11
+6449 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6449:11
+6449 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6449:15
+6449 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6453:3
+6453 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6453:8
+6453 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6453:10
+6453 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6453:14
+6453 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6458:0
+6458 | }
+     | ^
+error: expected `}`
+- error_stresstest:6462:11
+6462 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6462:11
+6462 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6462:15
+6462 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6466:3
+6466 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6466:8
+6466 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6466:10
+6466 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6466:14
+6466 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6471:0
+6471 | }
+     | ^
+error: expected `}`
+- error_stresstest:6475:11
+6475 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6475:11
+6475 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6475:15
+6475 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6479:3
+6479 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6479:8
+6479 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6479:10
+6479 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6479:14
+6479 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6484:0
+6484 | }
+     | ^
+error: expected `}`
+- error_stresstest:6488:11
+6488 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6488:11
+6488 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6488:15
+6488 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6492:3
+6492 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6492:8
+6492 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6492:10
+6492 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6492:14
+6492 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6497:0
+6497 | }
+     | ^
+error: expected `}`
+- error_stresstest:6501:11
+6501 |   msg: own bool,
+     |            ^^^^
+error: no macro with this name
+- error_stresstest:6501:11
+6501 |   msg: own bool,
+     |            ^^^^
+error: unexpected character
+- error_stresstest:6501:15
+6501 |   msg: own bool,
+     |                ^
+error: no macro with this name
+- error_stresstest:6505:3
+6505 |    level: bool,
+     |    ^^^^^
+error: unexpected character
+- error_stresstest:6505:8
+6505 |    level: bool,
+     |         ^
+error: no macro with this name
+- error_stresstest:6505:10
+6505 |    level: bool,
+     |           ^^^^
+error: unexpected character
+- error_stresstest:6505:14
+6505 |    level: bool,
+     |               ^
+error: unexpected character
+- error_stresstest:6510:0
+6510 | }
+     | ^


### PR DESCRIPTION
Fixes performance in the stresstest via two improvements:

* Caches the line indices so they can be reused for multiple errors in the same file
* Binary searches the line indices for the line extents

Combined, these improve performances of the stresstest in the samples directory from not finishing in reasonable time to outputting error messages in a couple seconds in debug mode.