### PR TITLE
Struct init field hover, goto-def, and find-all-refs

### DIFF
--- a/components/lark-type-check/src/hir_typeck.rs
+++ b/components/lark-type-check/src/hir_typeck.rs
@@ -1,4 +1,3 @@
-use lark_pretty_print::PrettyPrint;
 use crate::TypeCheckDatabase;
 use crate::TypeChecker;
 use crate::TypeCheckerFamily;
@@ -12,6 +11,7 @@ use lark_error::ErrorReported;
 use lark_error::ErrorSentinel;
 use lark_hir as hir;
 use lark_intern::Untern;
+use lark_pretty_print::PrettyPrint;
 use lark_ty::declaration::Declaration;
 use lark_ty::Signature;
 use lark_ty::Ty;


### PR DESCRIPTION
This adds the missing support for struct init fields to find-all-references and goto-definition. This fixes https://github.com/lark-exploration/lark/issues/153 as well by fixing hovers for struct init fields.