### PR TITLE
remove `LazyParsedEntityDatabase` trait

### DIFF
--- a/components/lark-parser/src/ir.rs
+++ b/components/lark-parser/src/ir.rs
@@ -1,7 +1,7 @@
 use crate::syntax::entity::InvalidParsedEntity;
 use crate::syntax::entity::LazyParsedEntity;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::entity::ParsedEntity;
+use crate::ParserDatabase;
 
 use derive_new::new;
 use lark_collections::Seq;
@@ -32,7 +32,7 @@ impl LazyParsedEntity for ParsedFile {
     fn parse_children(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Seq<ParsedEntity>> {
         WithError::ok(self.entities.clone())
     }
@@ -40,7 +40,7 @@ impl LazyParsedEntity for ParsedFile {
     fn parse_generic_declarations(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<Arc<ty::GenericDeclarations>, ErrorReported>> {
         InvalidParsedEntity.parse_generic_declarations(entity, db)
     }
@@ -48,7 +48,7 @@ impl LazyParsedEntity for ParsedFile {
     fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         InvalidParsedEntity.parse_type(entity, db)
     }
@@ -56,16 +56,12 @@ impl LazyParsedEntity for ParsedFile {
     fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         InvalidParsedEntity.parse_signature(entity, db)
     }
 
-    fn parse_fn_body(
-        &self,
-        entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
-    ) -> WithError<hir::FnBody> {
+    fn parse_fn_body(&self, entity: Entity, db: &dyn ParserDatabase) -> WithError<hir::FnBody> {
         InvalidParsedEntity.parse_fn_body(entity, db)
     }
 }

--- a/components/lark-parser/src/macros/function_declaration.rs
+++ b/components/lark-parser/src/macros/function_declaration.rs
@@ -1,13 +1,13 @@
 use crate::macros::EntityMacroDefinition;
 use crate::parser::Parser;
 use crate::syntax::entity::LazyParsedEntity;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::entity::ParsedEntity;
 use crate::syntax::entity::ParsedEntityThunk;
 use crate::syntax::fn_signature::FunctionSignature;
 use crate::syntax::fn_signature::ParsedFunctionSignature;
 use crate::syntax::identifier::SpannedGlobalIdentifier;
 use crate::syntax::skip_newline::SkipNewline;
+use crate::ParserDatabase;
 use lark_collections::Seq;
 use lark_debug_derive::DebugWith;
 use lark_debug_with::DebugWith;
@@ -78,7 +78,7 @@ impl LazyParsedEntity for ParsedFunctionDeclaration {
     fn parse_children(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Seq<ParsedEntity>> {
         WithError::ok(Seq::default())
     }
@@ -86,7 +86,7 @@ impl LazyParsedEntity for ParsedFunctionDeclaration {
     fn parse_generic_declarations(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Result<Arc<GenericDeclarations>, ErrorReported>> {
         // FIXME -- no support for generics yet
         WithError::ok(Ok(GenericDeclarations::empty(None)))
@@ -95,7 +95,7 @@ impl LazyParsedEntity for ParsedFunctionDeclaration {
     fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         // For each function `foo`, create a unique type `foo` as in
         // Rust.
@@ -118,16 +118,12 @@ impl LazyParsedEntity for ParsedFunctionDeclaration {
     fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         self.signature.parse_signature(entity, db, None)
     }
 
-    fn parse_fn_body(
-        &self,
-        entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
-    ) -> WithError<hir::FnBody> {
+    fn parse_fn_body(&self, entity: Entity, db: &dyn ParserDatabase) -> WithError<hir::FnBody> {
         self.signature.parse_fn_body(entity, db, None)
     }
 }

--- a/components/lark-parser/src/macros/struct_declaration.rs
+++ b/components/lark-parser/src/macros/struct_declaration.rs
@@ -2,14 +2,14 @@ use crate::macros::EntityMacroDefinition;
 use crate::parser::Parser;
 use crate::syntax::delimited::Delimited;
 use crate::syntax::entity::{
-    InvalidParsedEntity, LazyParsedEntity, LazyParsedEntityDatabase, ParsedEntity,
-    ParsedEntityThunk,
+    InvalidParsedEntity, LazyParsedEntity, ParsedEntity, ParsedEntityThunk,
 };
 use crate::syntax::identifier::SpannedGlobalIdentifier;
 use crate::syntax::list::CommaList;
 use crate::syntax::member::{Member, ParsedMember};
 use crate::syntax::sigil::Curlies;
 use crate::syntax::skip_newline::SkipNewline;
+use crate::ParserDatabase;
 use lark_collections::Seq;
 use lark_debug_with::DebugWith;
 use lark_entity::Entity;
@@ -85,7 +85,7 @@ impl LazyParsedEntity for ParsedStructDeclaration {
     fn parse_children(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Seq<ParsedEntity>> {
         WithError::ok(
             self.fields
@@ -136,7 +136,7 @@ impl LazyParsedEntity for ParsedStructDeclaration {
     fn parse_generic_declarations(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Result<Arc<ty::GenericDeclarations>, ErrorReported>> {
         // FIXME -- no support for generics yet
         WithError::ok(Ok(ty::GenericDeclarations::empty(None)))
@@ -145,7 +145,7 @@ impl LazyParsedEntity for ParsedStructDeclaration {
     fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         InvalidParsedEntity.parse_signature(entity, db)
     }
@@ -153,7 +153,7 @@ impl LazyParsedEntity for ParsedStructDeclaration {
     fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         // For each struct `Foo`, the "type" is just `own Foo`
         match db.generic_declarations(entity).into_value() {
@@ -172,11 +172,7 @@ impl LazyParsedEntity for ParsedStructDeclaration {
         }
     }
 
-    fn parse_fn_body(
-        &self,
-        entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
-    ) -> WithError<hir::FnBody> {
+    fn parse_fn_body(&self, entity: Entity, db: &dyn ParserDatabase) -> WithError<hir::FnBody> {
         panic!(
             "cannot parse fn body of a struct: {:?}",
             entity.debug_with(db)

--- a/components/lark-parser/src/syntax/expression/scope.rs
+++ b/components/lark-parser/src/syntax/expression/scope.rs
@@ -1,5 +1,5 @@
 use crate::parser::Parser;
-use crate::syntax::entity::LazyParsedEntityDatabase;
+use crate::ParserDatabase;
 use lark_collections::FxIndexMap;
 use lark_debug_with::DebugWith;
 use lark_entity::Entity;
@@ -11,7 +11,7 @@ use lark_string::{GlobalIdentifier, GlobalIdentifierTables};
 use std::rc::Rc;
 
 crate struct ExpressionScope<'parse> {
-    crate db: &'parse dyn LazyParsedEntityDatabase,
+    crate db: &'parse dyn ParserDatabase,
     crate item_entity: Entity,
 
     // FIXME -- we should not need to make *global identifiers* here,

--- a/components/lark-parser/src/syntax/fn_body.rs
+++ b/components/lark-parser/src/syntax/fn_body.rs
@@ -1,7 +1,6 @@
 use crate::lexer::token::LexToken;
 use crate::macros::EntityMacroDefinition;
 use crate::parser::Parser;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::expression::ident::HirIdentifier;
 use crate::syntax::expression::scope::ExpressionScope;
 use crate::syntax::expression::{HirExpression, ParsedStatement};
@@ -9,6 +8,7 @@ use crate::syntax::guard::Guard;
 use crate::syntax::sigil::{Equals, Let};
 use crate::syntax::skip_newline::SkipNewline;
 use crate::syntax::Syntax;
+use crate::ParserDatabase;
 use derive_new::new;
 use lark_collections::{FxIndexMap, Seq};
 use lark_debug_derive::DebugWith;
@@ -106,7 +106,7 @@ use std::sync::Arc;
 /// value of a `const` and so forth.
 crate fn parse_fn_body(
     item_entity: Entity,
-    db: &dyn LazyParsedEntityDatabase,
+    db: &dyn ParserDatabase,
     entity_macro_definitions: &FxIndexMap<GlobalIdentifier, Arc<dyn EntityMacroDefinition>>,
     input: &Text,                              // complete Text of file
     tokens: &Seq<Spanned<LexToken, FileName>>, // subset of Token corresponding to this expression

--- a/components/lark-parser/src/syntax/fn_signature.rs
+++ b/components/lark-parser/src/syntax/fn_signature.rs
@@ -2,7 +2,6 @@ use crate::parser::Parser;
 use crate::syntax::delimited::Delimited;
 use crate::syntax::entity::ErrorParsedEntity;
 use crate::syntax::entity::LazyParsedEntity;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::fn_body;
 use crate::syntax::guard::Guard;
 use crate::syntax::identifier::SpannedGlobalIdentifier;
@@ -15,6 +14,7 @@ use crate::syntax::skip_newline::SkipNewline;
 use crate::syntax::type_reference::ParsedTypeReference;
 use crate::syntax::type_reference::TypeReference;
 use crate::syntax::Syntax;
+use crate::ParserDatabase;
 use lark_collections::Seq;
 use lark_debug_derive::DebugWith;
 use lark_entity::Entity;
@@ -72,7 +72,7 @@ impl ParsedFunctionSignature {
     pub fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
         self_ty: Option<ty::Ty<Declaration>>,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         let mut errors = vec![];
@@ -99,7 +99,7 @@ impl ParsedFunctionSignature {
     pub fn parse_fn_body(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
         self_argument: Option<Spanned<GlobalIdentifier, FileName>>,
     ) -> WithError<hir::FnBody> {
         match self.body {

--- a/components/lark-parser/src/syntax/member.rs
+++ b/components/lark-parser/src/syntax/member.rs
@@ -1,7 +1,6 @@
 use crate::parser::Parser;
 use crate::syntax::entity::InvalidParsedEntity;
 use crate::syntax::entity::LazyParsedEntity;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::entity::ParsedEntity;
 use crate::syntax::fn_signature::FunctionSignature;
 use crate::syntax::fn_signature::ParsedFunctionSignature;
@@ -11,6 +10,7 @@ use crate::syntax::sigil::Colon;
 use crate::syntax::skip_newline::SkipNewline;
 use crate::syntax::type_reference::{ParsedTypeReference, TypeReference};
 use crate::syntax::Syntax;
+use crate::ParserDatabase;
 use lark_collections::Seq;
 use lark_debug_derive::DebugWith;
 use lark_entity::Entity;
@@ -105,7 +105,7 @@ impl LazyParsedEntity for ParsedMethod {
     fn parse_children(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Seq<ParsedEntity>> {
         WithError::ok(Seq::default())
     }
@@ -113,7 +113,7 @@ impl LazyParsedEntity for ParsedMethod {
     fn parse_generic_declarations(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Result<Arc<ty::GenericDeclarations>, ErrorReported>> {
         WithError::ok(Ok(ty::GenericDeclarations::empty(None)))
     }
@@ -121,7 +121,7 @@ impl LazyParsedEntity for ParsedMethod {
     fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         // For each method `foo`, create a unique type `foo` as in
         // Rust.
@@ -144,18 +144,14 @@ impl LazyParsedEntity for ParsedMethod {
     fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         let parent_entity = entity.untern(&db).parent().unwrap();
         let parent_ty = db.ty(parent_entity).into_value();
         self.signature.parse_signature(entity, db, Some(parent_ty))
     }
 
-    fn parse_fn_body(
-        &self,
-        entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
-    ) -> WithError<hir::FnBody> {
+    fn parse_fn_body(&self, entity: Entity, db: &dyn ParserDatabase) -> WithError<hir::FnBody> {
         let self_argument: GlobalIdentifier = "self".intern(&db);
         let spanned_self_argument = Spanned {
             value: self_argument,
@@ -177,7 +173,7 @@ impl LazyParsedEntity for ParsedField {
     fn parse_children(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Seq<ParsedEntity>> {
         WithError::ok(Seq::default())
     }
@@ -185,7 +181,7 @@ impl LazyParsedEntity for ParsedField {
     fn parse_generic_declarations(
         &self,
         _entity: Entity,
-        _db: &dyn LazyParsedEntityDatabase,
+        _db: &dyn ParserDatabase,
     ) -> WithError<Result<Arc<ty::GenericDeclarations>, ErrorReported>> {
         WithError::ok(Ok(ty::GenericDeclarations::empty(None)))
     }
@@ -193,7 +189,7 @@ impl LazyParsedEntity for ParsedField {
     fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         self.ty.parse_type(entity, db)
     }
@@ -201,16 +197,12 @@ impl LazyParsedEntity for ParsedField {
     fn parse_signature(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<Result<ty::Signature<Declaration>, ErrorReported>> {
         InvalidParsedEntity.parse_signature(entity, db)
     }
 
-    fn parse_fn_body(
-        &self,
-        entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
-    ) -> WithError<hir::FnBody> {
+    fn parse_fn_body(&self, entity: Entity, db: &dyn ParserDatabase) -> WithError<hir::FnBody> {
         InvalidParsedEntity.parse_fn_body(entity, db)
     }
 }

--- a/components/lark-parser/src/syntax/type_reference.rs
+++ b/components/lark-parser/src/syntax/type_reference.rs
@@ -1,7 +1,7 @@
 use crate::parser::Parser;
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::syntax::identifier::SpannedGlobalIdentifier;
 use crate::syntax::Syntax;
+use crate::ParserDatabase;
 use lark_debug_derive::DebugWith;
 use lark_entity::Entity;
 use lark_error::{ErrorReported, ErrorSentinel, WithError};
@@ -45,7 +45,7 @@ impl ParsedTypeReference {
     pub fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         match self {
             ParsedTypeReference::Named(named) => named.parse_type(entity, db),
@@ -73,7 +73,7 @@ impl NamedTypeReference {
     pub fn parse_type(
         &self,
         entity: Entity,
-        db: &dyn LazyParsedEntityDatabase,
+        db: &dyn ParserDatabase,
     ) -> WithError<ty::Ty<Declaration>> {
         match db.resolve_name(entity, self.identifier.value) {
             Some(entity) => {

--- a/components/lark-parser/src/type_conversion.rs
+++ b/components/lark-parser/src/type_conversion.rs
@@ -1,4 +1,3 @@
-use crate::syntax::entity::LazyParsedEntityDatabase;
 use crate::ParserDatabase;
 use lark_debug_with::DebugWith;
 use lark_entity::{Entity, EntityData, LangItem};
@@ -123,7 +122,7 @@ crate fn signature(
     }
 }
 
-crate fn unit_ty(db: &dyn LazyParsedEntityDatabase) -> ty::Ty<Declaration> {
+crate fn unit_ty(db: &dyn ParserDatabase) -> ty::Ty<Declaration> {
     declaration_ty_named(
         &db,
         EntityData::LangItem(LangItem::Tuple(0)).intern(&db),


### PR DESCRIPTION
Now that `ParserDatabase` is dyn-capable, we don't need it, we can just `ParserDatabase` directly.