### PR TITLE
Fix repl support

### DIFF
--- a/components/lark-cli/src/lib.rs
+++ b/components/lark-cli/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
-#![feature(existential_type)]
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(const_fn)]

--- a/components/lark-cli/src/repl.rs
+++ b/components/lark-cli/src/repl.rs
@@ -39,19 +39,16 @@ pub fn get_body(db: &LarkDatabase) -> lark_error::WithError<std::sync::Arc<lark_
     panic!("Internal error: Lost track of function bytecode")
 }
 
-/// Get the second-to-last expression in a function whose last expression is a call to `void_()`
-fn second_to_last(tb: &hir::FnBodyTables, expr: hir::Expression) -> hir::Expression {
+/// Get the second-to-last expression in a function
+pub fn second_to_last(tb: &hir::FnBodyTables, expr: hir::Expression) -> hir::Expression {
     match tb[expr] {
         hir::ExpressionData::Let { body, initializer, .. } => match tb[body] {
             hir::ExpressionData::Sequence { .. } | hir::ExpressionData::Let { .. } => second_to_last(tb, body),
-            hir::ExpressionData::Call { .. } => initializer.unwrap_or(expr),
-            // If we get this, the `void_()` call isn't there and/or we forgot a case
-            x => panic!("Got let {:?}", x),
+            _ => initializer.unwrap_or(expr),
         }
         hir::ExpressionData::Sequence { first, second } => match tb[second] {
             hir::ExpressionData::Sequence { .. } | hir::ExpressionData::Let { .. } => second_to_last(tb, second),
-            hir::ExpressionData::Call { .. } => first,
-            x => panic!("Got sequence {:?}", x),
+            _ => first,
         },
         _ => expr,
     }

--- a/components/lark-cli/src/repl.rs
+++ b/components/lark-cli/src/repl.rs
@@ -105,7 +105,7 @@ pub fn repl() {
         db.query_mut(lark_parser::FileTextQuery).set(
             repl_filename,
             // This is something of a hack so that the last expression in the function has type `void`
-            format!("def void_() {}\ndef main() {{\n{}\nvoid_()\n}}", "{}", virtual_fn.join("\n")).into(),
+            format!("def void_() {{}}\ndef main() {{\n{}\nvoid_()\n}}", virtual_fn.join("\n")).into(),
         );
 
         let writer = StandardStream::stderr(ColorChoice::Auto);

--- a/components/lark-type-check/src/hir_typeck.rs
+++ b/components/lark-type-check/src/hir_typeck.rs
@@ -154,7 +154,8 @@ where
             }
 
             hir::ExpressionData::Sequence { first, second } => {
-                self.check_expression(CheckType(self.unit_type(), expression.into()), first);
+                // We don't care what type the first value has
+                self.check_expression(Synthesize, first);
                 self.check_expression(mode, second)
             }
 

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -82,4 +82,24 @@ mod tests {
 
         assert_eq!(result, " true\n>");
     }
+
+    #[test]
+    fn repl_test_print() {
+        let mut child_session = ChildSession::spawn();
+
+        let _ = child_session.receive();
+
+        child_session.send("let x = 12\n").unwrap();
+        let _result = child_session.receive().unwrap();
+
+        child_session.send("let y = 18\n").unwrap();
+        let _result = child_session.receive().unwrap();
+
+        child_session.send("x + y\n").unwrap();
+        // Get two lines
+        let mut result = child_session.receive().unwrap();
+        result.push_str(&child_session.receive().unwrap());
+
+        assert_eq!(result, " -> 30\n>");
+    }
 }


### PR DESCRIPTION
This should fix #145. The REPL now produces essentially this:

```scala
def void_() {}

def main() {
    // REPL code...
    void_()
}
```

I changed blocks to allow expressions of any type as long as they aren't the last expression in the block. The `void_()` call is necessary because the last expression in a `void` block still needs to return `void`. We could drop that restriction, but I think it's useful if people forget to write a return type on a function (that should be an error, not just discard the return value.)

I also made `lark_eval` print out the result of every expression in a sequence except the last one when in REPL mode, which will be a bad idea if and when the REPL gets support for defining functions (we don't want every expression in their bodies to be printed out!) but should be fine for now.